### PR TITLE
update mediator/Makefile to compile esmf 8.1.0

### DIFF
--- a/mediator/Makefile
+++ b/mediator/Makefile
@@ -3,13 +3,14 @@ $(error Environment variable ESMFMKFILE was not set.)
 endif
 
 include $(ESMFMKFILE)
+CPPDEFS += -DESMF_VERSION_MAJOR=$(ESMF_VERSION_MAJOR) -DESMF_VERSION_MINOR=$(ESMF_VERSION_MINOR)
 
 ifndef PIO_INCLUDE_DIR
 $(error PIO_INCLUDE_DIR not set)
 endif
 
 ifdef INTERNAL_PIO_INIT
-CPPDEFS := -DINTERNAL_PIO_INIT
+CPPDEFS += -DINTERNAL_PIO_INIT
 endif
 
 LIBRARY := libcmeps.a


### PR DESCRIPTION
### Description of changes

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): 4

Are changes expected to change answers (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (required) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [x ] (required) UFS-S2S testing
   - description: test s2s RT
   - details (e.g. failed tests): No failed test

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [x ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out: https://github.com/ufs-community/ufs-s2s-model
  - branch: develop
  - hash: 15966c5f
