### PR TITLE
Enable fine-grained timing in the mediator using ESMF

### DIFF
--- a/nems/util/perf_mod.F90
+++ b/nems/util/perf_mod.F90
@@ -13,14 +13,12 @@ contains
    subroutine t_startf(event, handle)
      character(len=*), intent(in) :: event
      integer,  optional :: handle
-     ! Do nothing for nems right now
      call ESMF_TraceRegionEnter(event)
    end subroutine t_startf
 
    subroutine t_stopf(event, handle)
      character(len=*), intent(in) :: event
      integer,  optional :: handle
-     ! Do nothing for nems right now
      call ESMF_TraceRegionExit(event)
    end subroutine t_stopf
 

--- a/nems/util/perf_mod.F90
+++ b/nems/util/perf_mod.F90
@@ -1,5 +1,7 @@
 module perf_mod
 
+  use ESMF
+
   implicit none
   public
 
@@ -12,12 +14,14 @@ contains
      character(len=*), intent(in) :: event
      integer,  optional :: handle
      ! Do nothing for nems right now
+     call ESMF_TraceRegionEnter(event)
    end subroutine t_startf
 
    subroutine t_stopf(event, handle)
      character(len=*), intent(in) :: event
      integer,  optional :: handle
      ! Do nothing for nems right now
+     call ESMF_TraceRegionExit(event)
    end subroutine t_stopf
 
 end module perf_mod


### PR DESCRIPTION
### Description of changes

CMEPS has some timing calls using t_startf() and t_stopf() functions, but these were not hooked up to the ESMF timers when CMEPS is used in UFS.  This PR adds the timing calls. The timed regions can then be viewed in the ESMF_Profile.summary file.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers?
 - [x] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
- [ ] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (required) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
- [x] (required) UFS-S2S testing
   - description:  ran RT cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt and saw mediator timings in profile
see /scratch1/NCEPDEV/stmp2/Rocky.Dunlap/S2S_RT/rt_75167/cpld_fv3_ccpp_384_mom6_cice_cmeps_ww3_1d_bmark_rt
   - details (e.g. failed tests):

Hashes used for testing:
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [x] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:  https://github.com/ufs-community/ufs-s2s-model
  - branch:
  - hash:  89c43dd83

The above is the head of the current develop branch of ufs-s2s-model. 
