### PR TITLE
build CMEPS with cmake and create a package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ cime_config/buildexec
 *.exe
 *.out
 *.app
+
+# Temporary files created by editors
+*.swp
+
+# Directories people create
+build*/
+install*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,191 @@
+cmake_minimum_required(VERSION 3.7...3.15 FATAL_ERROR)
+
+# Define the CMake project
+project(cmeps
+  VERSION 1.0.0
+  DESCRIPTION  "NUOPC based Community Mediator for Earth Prediction Systems"
+  HOMEPAGE_URL "https://escomp.github.io/CMEPS"
+  LANGUAGES Fortran)
+
+include(GNUInstallDirs)
+
+if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE
+      "Release"
+      CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|GNU)$")
+  message(WARNING "Compiler not officially supported: ${CMAKE_Fortran_COMPILER_ID}")
+endif()
+
+# Append directory that contains CMake Modules
+list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+# Build options
+option(CMEPS_BUILD_STATIC_LIBS "Build CMEPS static library" ON )
+option(CMEPS_BUILD_SHARED_LIBS "Build CMEPS shared library" OFF )
+
+# Ensure at least one of CMEPS_BUILD_SHARED_LIBS and CMEPS_BUILD_STATIC_LIBS is set
+if(NOT (CMEPS_BUILD_STATIC_LIBS OR CMEPS_BUILD_SHARED_LIBS))
+    message(STATUS "Niether CMEPS_BUILD_STATIC_LIBS nor CMEPS_BUILD_SHARED_LIBS is set.  Defaulting to CMEPS_BUILD_STATIC_LIBS=ON")
+    set(CMEPS_BUILD_STATIC_LIBS ON CACHE BOOL "Build CMEPS static library" FORCE)
+    set(CMEPS_BUILD_STATIC_LIBS ON)
+endif()
+
+message(STATUS "Option: CMEPS_BUILD_STATIC_LIBS: ${CMEPS_BUILD_STATIC_LIBS}")
+message(STATUS "Option: CMEPS_BUILD_SHARED_LIBS: ${CMEPS_BUILD_SHARED_LIBS}")
+
+find_package(MPI REQUIRED)
+find_package(ESMF MODULE REQUIRED)
+find_package(PIO REQUIRED COMPONENTS C Fortran)
+
+option(ENABLE_OPENMP "Build CMEPS with OpenMP support" OFF)
+if(ENABLE_OPENMP)
+  find_package(OpenMP REQUIRED)
+endif()
+
+list(APPEND _nems_util_files
+  nems/util/shr_abort_mod.F90
+  nems/util/shr_log_mod.F90
+  nems/util/shr_pio_mod.F90
+  nems/util/shr_sys_mod.F90
+  nems/util/shr_flux_mod.F90
+  nems/util/shr_mpi_mod.F90
+  nems/util/glc_elevclass_mod.F90
+  nems/util/shr_mem_mod.F90
+  nems/util/shr_kind_mod.F90
+  nems/util/perf_mod.F90
+  nems/util/shr_const_mod.F90)
+
+list(APPEND _mediator_src_files
+  mediator/med_phases_restart_mod.F90
+  mediator/med_map_mod.F90
+  mediator/med_methods_mod.F90
+  mediator/med_phases_prep_ice_mod.F90
+  mediator/med_phases_history_mod.F90
+  mediator/med_phases_prep_glc_mod.F90
+  mediator/med_internalstate_mod.F90
+  mediator/med_phases_profile_mod.F90
+  mediator/esmFldsExchange_hafs_mod.F90
+  mediator/med_phases_prep_rof_mod.F90
+  mediator/esmFldsExchange_cesm_mod.F90
+  mediator/med_merge_mod.F90
+  mediator/med_constants_mod.F90
+  mediator/med_kind_mod.F90
+  mediator/esmFldsExchange_nems_mod.F90
+  mediator/med_phases_prep_lnd_mod.F90
+  mediator/med_phases_prep_atm_mod.F90
+  mediator/med_phases_prep_ocn_mod.F90
+  mediator/esmFlds.F90
+  mediator/med.F90
+  mediator/med_time_mod.F90
+  mediator/med_phases_ocnalb_mod.F90
+  mediator/med_phases_prep_wav_mod.F90
+  mediator/med_utils_mod.F90
+  mediator/med_fraction_mod.F90
+  mediator/med_phases_aofluxes_mod.F90
+  mediator/med_io_mod.F90)
+
+### Package compiler flags
+include(cmeps_compiler_flags)
+
+### Package compilation properties
+set(_inc_dir "include")
+set(_mod_dir ${CMAKE_CURRENT_BINARY_DIR}/${_inc_dir})
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+### Use common object library for building shared and static targets
+add_library(nems_util_obj OBJECT ${_nems_util_files})
+set_target_properties(nems_util_obj PROPERTIES Fortran_MODULE_DIRECTORY ${_mod_dir})
+target_include_directories(nems_util_obj PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/nems/util>)
+target_link_libraries(nems_util_obj PRIVATE esmf
+                                            PIO::PIO_C PIO::PIO_Fortran
+                                            MPI::MPI_Fortran)
+if(OpenMP_Fortran_FOUND)
+  target_link_libraries(nems_util_obj PRIVATE OpenMP::OpenMP_Fortran)
+endif()
+
+add_library(mediator_obj OBJECT ${_mediator_src_files})
+set_target_properties(mediator_obj PROPERTIES Fortran_MODULE_DIRECTORY ${_mod_dir})
+target_include_directories(mediator_obj PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mediator>)
+list(APPEND _mediator_defs ESMF_VERSION_MAJOR=${ESMF_VERSION_MAJOR}
+                           ESMF_VERSION_MINOR=${ESMF_VERSION_MINOR}
+                           INTERNAL_PIO_INIT)
+target_compile_definitions(mediator_obj PRIVATE "${_mediator_defs}")
+target_link_libraries(mediator_obj PRIVATE nems_util_obj
+                                           esmf
+                                           PIO::PIO_C PIO::PIO_Fortran
+                                           MPI::MPI_Fortran)
+if(OpenMP_Fortran_FOUND)
+  target_link_libraries(mediator_obj PRIVATE OpenMP::OpenMP_Fortran)
+endif()
+
+### Add static lib target
+if(CMEPS_BUILD_STATIC_LIBS)
+  add_library(${PROJECT_NAME}_static STATIC $<TARGET_OBJECTS:nems_util_obj>
+                                            $<TARGET_OBJECTS:mediator_obj>)
+  add_library(${PROJECT_NAME}::${PROJECT_NAME}_static ALIAS ${PROJECT_NAME}_static)
+  list(APPEND _lib_targets ${PROJECT_NAME}_static)
+endif()
+
+### Add shared lib target
+if(CMEPS_BUILD_SHARED_LIBS)
+  add_library(${PROJECT_NAME}_shared SHARED $<TARGET_OBJECTS:nems_util_obj>
+                                            $<TARGET_OBJECTS:mediator_obj>)
+  add_library(${PROJECT_NAME}::${PROJECT_NAME}_shared ALIAS ${PROJECT_NAME}_shared)
+  list(APPEND _lib_targets ${PROJECT_NAME}_shared)
+endif()
+
+### Set common lib target properties
+set_target_properties(${_lib_targets} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+foreach( _tgt IN LISTS _lib_targets)
+  target_compile_definitions(${_tgt} PUBLIC "${_mediator_defs}")
+  target_include_directories(${_tgt} PUBLIC $<BUILD_INTERFACE:${_mod_dir}>
+                                            $<INSTALL_INTERFACE:${_inc_dir}>)
+  target_link_libraries(${_tgt} PUBLIC esmf
+                                       PIO::PIO_C PIO::PIO_Fortran
+                                       MPI::MPI_Fortran)
+  if(OpenMP_Fortran_FOUND)
+    target_link_libraries(${_tgt} PUBLIC OpenMP::OpenMP_Fortran)
+  endif()
+  set_property(TARGET ${_tgt} PROPERTY FOLDER ${PROJECT_NAME})
+endforeach()
+
+### Install
+install(
+  TARGETS ${_lib_targets}
+  EXPORT ${PROJECT_NAME}Exports
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(DIRECTORY   ${_mod_dir}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+### Package config
+include(CMakePackageConfigHelpers)
+set(CONFIG_INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
+
+export(EXPORT ${PROJECT_NAME}Exports
+  NAMESPACE ${PROJECT_NAME}::
+  FILE ${PROJECT_NAME}-targets.cmake)
+
+configure_package_config_file(
+  ${CMAKE_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
+install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+  DESTINATION ${CONFIG_INSTALL_DESTINATION})
+
+write_basic_package_version_file(
+  ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+  DESTINATION ${CONFIG_INSTALL_DESTINATION})
+
+install(EXPORT ${PROJECT_NAME}Exports
+  NAMESPACE ${PROJECT_NAME}::
+  FILE ${PROJECT_NAME}-targets.cmake
+  DESTINATION ${CONFIG_INSTALL_DESTINATION})

--- a/cmake/CMEPSConfig.cmake.in
+++ b/cmake/CMEPSConfig.cmake.in
@@ -1,0 +1,105 @@
+@PACKAGE_INIT@
+
+#@PROJECT_NAME@-config.cmake
+#
+# Valid Find COMPONENTS:
+#  * STATIC - Has static targets
+#  * SHARED - Has shared targets
+#
+# Variables provided:
+#  @PROJECT_NAME@_FOUND - True if @PROJECT_NAME@ is found
+#  @PROJECT_NAME@_VERSION - Version of installed @PROJECT_NAME@
+#
+# Targets provided:
+#  @PROJECT_NAME@::@PROJECT_NAME@ - @PROJECT_NAME@ interface target aliased to SHARED|STATIC as requested or to shared libraries if available else static libraries
+#
+# To control finding of this package, set @PROJECT_NAME@_ROOT environment variable to the full path to the prefix
+# under which @PROJECT_NAME@ was installed (e.g., /usr/local)
+
+# Include targets file.  This will create IMPORTED target @PROJECT_NAME@
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-config-version.cmake")
+include(CMakeFindDependencyMacro)
+
+find_dependency(MPI)
+find_dependency(ESMF MODULE)
+find_dependency(PIO COMPONENTS C Fortran)
+
+# ON/OFF implies @PROJECT_NAME@ was compiled with/without OpenMP
+if(@OPENMP@)
+  find_dependency(OpenMP)
+endif()
+
+set(_search_components)
+set(_search_library_type)
+foreach(_comp ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS})
+  if(_comp MATCHES "^(STATIC|SHARED)$")
+    list(APPEND _search_library_type ${_comp})
+  else()
+    list(APPEND _search_components ${_comp})
+  endif()
+endforeach()
+#set( ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS ${_search_components} )
+
+# Ensure there is only one type of library being requested
+if(_search_library_type)
+  list(LENGTH _search_library_type _len)
+  if(_len GREATER 1)
+    message(FATAL_ERROR "User requesting both STATIC and SHARED is not permissible")
+  endif()
+  unset(_len)
+endif()
+
+set(@PROJECT_NAME@_LIBRARIES)
+set(@PROJECT_NAME@_STATIC_LIBRARIES)
+set(@PROJECT_NAME@_SHARED_LIBRARIES)
+
+set(@PROJECT_NAME@_FOUND 0)
+set(@PROJECT_NAME@_STATIC_FOUND 0)
+set(@PROJECT_NAME@_SHARED_FOUND 0)
+
+if(@CMEPS_BUILD_STATIC_LIBS@)
+  set(@PROJECT_NAME@_STATIC_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@_static)
+  set(@PROJECT_NAME@_STATIC_FOUND 1)
+  if(@CMEPS_BUILD_SHARED_LIBS@)
+    set(@PROJECT_NAME@_SHARED_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@_shared)
+    set(@PROJECT_NAME@_SHARED_FOUND 1)
+  endif()
+elseif(@CMEPS_BUILD_SHARED_LIBS@)
+  set(@PROJECT_NAME@_SHARED_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@_shared)
+  set(@PROJECT_NAME@_SHARED_FOUND 1)
+else()
+  set(@PROJECT_NAME@_NOT_FOUND_MESSAGE "Neither CMEPS_BUILD_SHARED_LIBS nor CMEPS_BUILD_STATIC_LIBS was set.  Unable to find any libraries.")
+endif()
+
+if(NOT _search_library_type)
+  if(@PROJECT_NAME@_STATIC_FOUND)
+    set(_search_library_type STATIC)
+  elseif(@PROJECT_NAME@_SHARED_FOUND)
+    set(_search_library_type SHARED)
+  endif()
+endif()
+
+if(_search_library_type MATCHES "^(SHARED)$" AND @PROJECT_NAME@_SHARED_FOUND)
+  if(TARGET @PROJECT_NAME@::@PROJECT_NAME@_shared)
+    add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@:@PROJECT_NAME@_shared)
+    set(@PROJECT_NAME@_FOUND 1)
+  endif()
+elseif(_search_library_type MATCHES "^(STATIC)$" AND @PROJECT_NAME@_STATIC_FOUND)
+  if(TARGET @PROJECT_NAME@::@PROJECT_NAME@_static)
+    add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@:@PROJECT_NAME@_static)
+    set(@PROJECT_NAME@_FOUND 1)
+  endif()
+else()
+
+get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@ IMPORTED_CONFIGURATIONS)
+get_property(@PROJECT_NAME@_LIBRARIES TARGET @PROJECT_NAME@::@PROJECT_NAME@ PROPERTY LOCATION)
+
+check_required_components("@PROJECT_NAME@")
+
+set(@PROJECT_NAME@Version "${PACKAGE_VERSION}")
+set_and_check(@PROJECT_NAME@_INSTALL_PREFIX "${PACKAGE_PREFIX_DIR}")
+
+message(STATUS "Found @PROJECT_NAME@: \"${@PROJECT_NAME@_INSTALL_PREFIX}\" (Version: \"${@PROJECT_NAME@Version}\")")
+message( STATUS "@PROJECT_NAME@ targets:" )
+message(STATUS "  - @PROJECT_NAME@::@PROJECT_NAME@ [Lib: ${@PROJECT_NAME@_LIBRARIES}]")

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -1,0 +1,105 @@
+# - Try to find ESMF
+#
+# Requires setting ESMFMKFILE to the filepath of esmf.mk. If this is NOT set,
+# then ESMF_FOUND will always be FALSE. If ESMFMKFILE exists, then ESMF_FOUND=TRUE
+# and all ESMF makefile variables will be set in the global scope. Optionally,
+# set ESMF_MKGLOBALS to a string list to filter makefile variables. For example,
+# to globally scope only ESMF_LIBSDIR and ESMF_APPSDIR variables, use this CMake
+# command in CMakeLists.txt:
+#
+#   set(ESMF_MKGLOBALS "LIBSDIR" "APPSDIR")
+
+
+# Add the ESMFMKFILE path to the cache if defined as system env variable
+if (DEFINED ENV{ESMFMKFILE} AND NOT DEFINED ESMFMKFILE)
+  set(ESMFMKFILE $ENV{ESMFMKFILE} CACHE FILEPATH "Path to ESMF mk file")
+endif ()
+
+# Found the mk file and ESMF exists on the system
+if (EXISTS ${ESMFMKFILE})
+  set(ESMF_FOUND TRUE CACHE BOOL "ESMF mk file found" FORCE)
+  # Did not find the ESMF mk file
+else()
+  set(ESMF_FOUND FALSE CACHE BOOL "ESMF mk file NOT found" FORCE)
+  # Best to warn users that without the mk file there is no way to find ESMF
+  if (NOT DEFINED ESMFMKFILE)
+    message(FATAL_ERROR "ESMFMKFILE not defined. This is the path to esmf.mk file. \
+Without this filepath, ESMF_FOUND will always be FALSE.")
+  endif ()
+endif()
+
+# Only parse the mk file if it is found
+if (ESMF_FOUND)
+  # Read the mk file
+  file(STRINGS "${ESMFMKFILE}" esmfmkfile_contents)
+  # Parse each line in the mk file
+  foreach(str ${esmfmkfile_contents})
+    # Only consider uncommented lines
+    string(REGEX MATCH "^[^#]" def ${str})
+    # Line is not commented
+    if (def)
+      # Extract the variable name
+      string(REGEX MATCH "^[^=]+" esmf_varname ${str})
+      # Extract the variable's value
+      string(REGEX MATCH "=.+$" esmf_vardef ${str})
+      # Only for variables with a defined value
+      if (esmf_vardef)
+        # Get rid of the assignment string
+        string(SUBSTRING ${esmf_vardef} 1 -1 esmf_vardef)
+        # Remove whitespace
+        string(STRIP ${esmf_vardef} esmf_vardef)
+        # A string or single-valued list
+        if(NOT DEFINED ESMF_MKGLOBALS)
+          # Set in global scope
+          set(${esmf_varname} ${esmf_vardef})
+          # Don't display by default in GUI
+          mark_as_advanced(esmf_varname)
+        else() # Need to filter global promotion
+          foreach(m ${ESMF_MKGLOBALS})
+            string(FIND ${esmf_varname} ${m} match)
+            # Found the string
+            if(NOT ${match} EQUAL -1)
+              # Promote to global scope
+              set(${esmf_varname} ${esmf_vardef})
+              # Don't display by default in the GUI
+              mark_as_advanced (esmf_varname)
+              # No need to search for the current string filter
+              break()
+            endif()
+          endforeach()
+        endif()
+      endif()
+    endif()
+  endforeach()
+
+  separate_arguments(ESMF_F90COMPILEPATHS NATIVE_COMMAND ${ESMF_F90COMPILEPATHS})
+  foreach (ITEM ${ESMF_F90COMPILEPATHS})
+     string(REGEX REPLACE "^-I" "" ITEM "${ITEM}")
+     list(APPEND tmp ${ITEM})
+  endforeach()
+  set(ESMF_F90COMPILEPATHS ${tmp})
+
+  add_library(esmf UNKNOWN IMPORTED)
+  # Look for static library, if not found try dynamic library
+  find_library(esmf_lib NAMES libesmf.a PATHS ${ESMF_LIBSDIR})
+  if(esmf_lib MATCHES "esmf_lib-NOTFOUND")
+    message(STATUS "Static ESMF library not found, searching for dynamic library instead")
+    find_library(esmf_lib NAMES esmf_fullylinked PATHS ${ESMF_LIBSDIR})
+    if(esmf_lib MATCHES "esmf_lib-NOTFOUND")
+      message(FATAL_ERROR "Neither the dynamic nor the static ESMF library was found")
+    else()
+      message(STATUS "Found ESMF library: ${esmf_lib}")
+    endif()
+    set(ESMF_INTERFACE_LINK_LIBRARIES "")
+  else()
+    # When linking the static library, also need the ESMF linker flags; strip any leading/trailing whitespaces
+    string(STRIP "${ESMF_F90ESMFLINKRPATHS} ${ESMF_F90ESMFLINKPATHS} ${ESMF_F90LINKPATHS} ${ESMF_F90LINKLIBS} ${ESMF_F90LINKOPTS}" ESMF_INTERFACE_LINK_LIBRARIES)
+    message(STATUS "Found ESMF library: ${esmf_lib}")
+  endif()
+
+  set_target_properties(esmf PROPERTIES
+    IMPORTED_LOCATION ${esmf_lib}
+    INTERFACE_INCLUDE_DIRECTORIES "${ESMF_F90COMPILEPATHS}"
+    INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
+
+endif()

--- a/cmake/FindPIO.cmake
+++ b/cmake/FindPIO.cmake
@@ -1,0 +1,203 @@
+# FindPIO.cmake
+#
+# Copyright UCAR 2020
+# Copyright NOAA/NWS/NCEP/EMC 2020
+#
+# Find PIO: A high-level Parallel I/O Library for structured grid applications
+# https://github.com/NCAR/ParallelIO
+#
+# Components available for query:
+#  C - Has C support
+#  Fortran - Has Fortran support
+#  SHARED - Has shared targets
+#  STATIC - Has static targets
+#
+# Variables provided:
+#  PIO_FOUND - True if PIO was found
+#  PIO_C_FOUND - True if PIO C support was found
+#  PIO_Fortran_FOUND - True if PIO Fortran support was found
+#  PIO_VERSION - Version of installed PIO
+#
+# Targets provided:
+#  PIO::PIO_C - C interface target aliased to SHARED|STATIC as requested or to shared libraries if available else static libraries
+#  PIO::PIO_Fortran - Fortran interface target aliases to SHARED|STATIC as requested or to shared libraries if available else static libraries
+#
+# To control finding of this package, set PIO_ROOT environment variable to the full path to the prefix
+# under which PIO was installed (e.g., /usr/local)
+
+set( _search_components )
+set( _search_library_type )
+foreach( _comp ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS} )
+    if( _comp MATCHES "^(STATIC|SHARED)$" )
+        list( APPEND _search_library_type ${_comp} )
+    else()
+        list( APPEND _search_components ${_comp} )
+    endif()
+endforeach()
+set( ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS ${_search_components} )
+
+# If no COMPONENTS are requested, seach both C and Fortran
+if( NOT _search_components )
+    list( APPEND _search_components C Fortran )
+endif()
+
+# Ensure there is only one type of library being requested
+if( _search_library_type )
+    list( LENGTH _search_library_type _len)
+    if( _len GREATER 1 )
+        message(FATAL_ERROR "User requesting both STATIC and SHARED is not permissible")
+    endif()
+    unset(_len)
+endif()
+
+## Find libraries and paths, and determine found components
+find_path(PIO_INCLUDE_DIR NAMES pio.h HINTS "${PIO_PREFIX}" PATH_SUFFIXES include include/pio)
+if(PIO_INCLUDE_DIR)
+    string(REGEX REPLACE "/include(/.+)?" "" PIO_PREFIX ${PIO_INCLUDE_DIR})
+    set(PIO_PREFIX ${PIO_PREFIX} CACHE STRING "")
+    find_path(PIO_MODULE_DIR NAMES pio.mod PATHS "${PIO_PREFIX}"
+              PATH_SUFFIXES include include/pio lib/pio/module module module/pio NO_DEFAULT_PATH)
+    find_library(PIO_C_STATIC_LIB libpioc.a PATHS "${PIO_PREFIX}" PATH_SUFFIXES lib lib64 NO_DEFAULT_PATH)
+    find_library(PIO_C_SHARED_LIB libpioc.so PATHS "${PIO_PREFIX}" PATH_SUFFIXES lib lib64 NO_DEFAULT_PATH)
+    find_library(PIO_Fortran_STATIC_LIB libpiof.a PATHS "${PIO_PREFIX}" PATH_SUFFIXES lib lib64 NO_DEFAULT_PATH)
+    find_library(PIO_Fortran_SHARED_LIB libpiof.so PATHS "${PIO_PREFIX}" PATH_SUFFIXES lib lib64 NO_DEFAULT_PATH)
+    #Check for Fortran components
+    if(PIO_MODULE_DIR)
+        if(PIO_Fortran_STATIC_LIB)
+            set(PIO_Fortran_STATIC_FOUND 1)
+        endif()
+        if(PIO_Fortran_SHARED_LIB)
+            set(PIO_Fortran_SHARED_FOUND 1)
+        endif()
+    endif()
+    #Check for C components
+    if(PIO_C_STATIC_LIB)
+        set(PIO_C_STATIC_FOUND 1)
+    endif()
+    if(PIO_C_SHARED_LIB)
+        set(PIO_C_SHARED_FOUND 1)
+    endif()
+endif()
+## Debugging output
+message(DEBUG "[FindPIO] PIO_INCLUDE_DIR: ${PIO_INCLUDE_DIR}")
+message(DEBUG "[FindPIO] PIO_PREFIX: ${PIO_PREFIX}")
+message(DEBUG "[FindPIO] PIO_MODULE_DIR: ${PIO_MODULE_DIR}")
+message(DEBUG "[FindPIO] PIO_C_STATIC_LIB: ${PIO_C_STATIC_LIB}")
+message(DEBUG "[FindPIO] PIO_C_SHARED_LIB: ${PIO_C_SHARED_LIB}")
+message(DEBUG "[FindPIO] PIO_C_SHARED_FOUND: ${PIO_C_SHARED_FOUND}")
+message(DEBUG "[FindPIO] PIO_C_STATIC_FOUND: ${PIO_C_STATIC_FOUND}")
+message(DEBUG "[FindPIO] PIO_Fortran_STATIC_LIB: ${PIO_Fortran_STATIC_LIB}")
+message(DEBUG "[FindPIO] PIO_Fortran_SHARED_LIB: ${PIO_Fortran_SHARED_LIB}")
+message(DEBUG "[FindPIO] PIO_Fortran_SHARED_FOUND: ${PIO_Fortran_SHARED_FOUND}")
+message(DEBUG "[FindPIO] PIO_Fortran_STATIC_FOUND: ${PIO_Fortran_STATIC_FOUND}")
+
+## Create targets
+set(_new_components)
+# PIO_C_STATIC imported interface target
+if(PIO_C_STATIC_FOUND AND NOT TARGET PIO_C_STATIC)
+    add_library(PIO_C_STATIC INTERFACE IMPORTED)
+    set_target_properties(PIO_C_STATIC PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES ${PIO_INCLUDE_DIR}
+                          INTERFACE_LINK_LIBRARIES ${PIO_C_STATIC_LIB}
+                          IMPORTED_GLOBAL True )
+    set(_new_components 1)
+endif()
+# PIO_C_SHARED imported interface target
+if(PIO_C_SHARED_FOUND AND NOT TARGET PIO_C_SHARED)
+    add_library(PIO_C_SHARED INTERFACE IMPORTED)
+    set_target_properties(PIO_C_SHARED PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES ${PIO_INCLUDE_DIR}
+                          INTERFACE_LINK_LIBRARIES ${PIO_C_SHARED_LIB}
+                          IMPORTED_GLOBAL True )
+    set(_new_components 1)
+endif()
+# PIO_Fortran_STATIC imported interface target
+if(PIO_Fortran_STATIC_FOUND AND NOT TARGET PIO_Fortran_STATIC)
+    add_library(PIO_Fortran_STATIC INTERFACE IMPORTED)
+    set_target_properties(PIO_Fortran_STATIC PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES ${PIO_INCLUDE_DIR}
+                          INTERFACE_LINK_LIBRARIES ${PIO_Fortran_STATIC_LIB}
+                          IMPORTED_GLOBAL True )
+    if(PIO_MODULE_DIR AND NOT PIO_MODULE_DIR STREQUAL PIO_INCLUDE_DIR )
+        set_property(TARGET PIO_Fortran_STATIC APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PIO_MODULE_DIR})
+    endif()
+    set(_new_components 1)
+    target_link_libraries(PIO_Fortran_STATIC INTERFACE PIO_C_STATIC)
+endif()
+# PIO_Fortran_SHARED imported interface target
+if(PIO_Fortran_SHARED_FOUND AND NOT TARGET PIO_Fortran_SHARED)
+    add_library(PIO_Fortran_SHARED INTERFACE IMPORTED)
+    set_target_properties(PIO_Fortran_SHARED PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES ${PIO_INCLUDE_DIR}
+                          INTERFACE_LINK_LIBRARIES ${PIO_Fortran_SHARED_LIB}
+                          IMPORTED_GLOBAL True )
+    if(PIO_MODULE_DIR AND NOT PIO_MODULE_DIR STREQUAL PIO_INCLUDE_DIR )
+        set_property(TARGET PIO_Fortran_SHARED APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PIO_MODULE_DIR})
+    endif()
+    target_link_libraries(PIO_Fortran_SHARED INTERFACE PIO_C_SHARED)
+    set(_new_components 1)
+endif()
+
+if( _search_library_type MATCHES "^(SHARED)$" )
+  if( TARGET PIO_C_SHARED )
+      add_library(PIO::PIO_C ALIAS PIO_C_SHARED)
+      set(PIO_C_FOUND 1)
+  endif()
+  if( TARGET PIO_Fortran_SHARED )
+      add_library(PIO::PIO_Fortran ALIAS PIO_Fortran_SHARED)
+      set(PIO_Fortran_FOUND 1)
+  endif()
+elseif( _search_library_type MATCHES "^(STATIC)$" )
+  if( TARGET PIO_C_STATIC )
+      add_library(PIO::PIO_C ALIAS PIO_C_STATIC)
+      set(PIO_C_FOUND 1)
+  endif()
+  if( TARGET PIO_Fortran_STATIC )
+      add_library(PIO::PIO_Fortran ALIAS PIO_Fortran_STATIC)
+      set(PIO_Fortran_FOUND 1)
+  endif()
+else()
+  if( TARGET PIO_C_SHARED )
+        add_library(PIO::PIO_C ALIAS PIO_C_SHARED)
+        set(PIO_C_FOUND 1)
+  elseif( TARGET PIO_C_STATIC )
+        add_library(PIO::PIO_C ALIAS PIO_C_STATIC)
+        set(PIO_C_FOUND 1)
+  endif()
+  if( TARGET PIO_Fortran_SHARED )
+      add_library(PIO::PIO_Fortran ALIAS PIO_Fortran_SHARED)
+      set(PIO_Fortran_FOUND 1)
+  elseif( TARGET PIO_Fortran_STATIC )
+      add_library(PIO::PIO_Fortran ALIAS PIO_Fortran_STATIC)
+      set(PIO_Fortran_FOUND 1)
+  endif()
+endif()
+
+## Check package has been found correctly
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  PIO
+  REQUIRED_VARS
+    PIO_PREFIX
+    PIO_INCLUDE_DIR
+  HANDLE_COMPONENTS
+)
+message(DEBUG "[FindPIO] PIO_FOUND: ${PIO_FOUND}")
+
+## Print status
+if(${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY AND _new_components)
+    message( STATUS "Find${CMAKE_FIND_PACKAGE_NAME}:" )
+    message( STATUS "  - ${CMAKE_FIND_PACKAGE_NAME}_PREFIX [${${CMAKE_FIND_PACKAGE_NAME}_PREFIX}]")
+    set(_found_comps)
+    foreach( _comp ${_search_components} )
+        if( ${CMAKE_FIND_PACKAGE_NAME}_${_comp}_FOUND )
+            list(APPEND _found_comps ${_comp})
+        endif()
+    endforeach()
+    message( STATUS "  - ${CMAKE_FIND_PACKAGE_NAME} Components Found: ${_found_comps}")
+    unset(_found_comps)
+endif()
+unset(_new_components)
+unset(_search_components)
+unset(_search_library_type)
+unset(_library_type)

--- a/cmake/cmeps_compiler_flags.cmake
+++ b/cmake/cmeps_compiler_flags.cmake
@@ -1,0 +1,11 @@
+################################################################################
+# Fortran
+################################################################################
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+  include(compiler_flags_GNU_Fortran)
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+  include(compiler_flags_Intel_Fortran)
+else()
+  message(WARNING "Fortran compiler with ID ${CMAKE_Fortran_COMPILER_ID} will be used with CMake default options")
+endif()

--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -1,0 +1,11 @@
+# GNU Fortan
+
+set(CMAKE_Fortran_FLAGS "-g -fbacktrace -ffree-line-length-none")
+
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}")
+
+set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
+
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow" )
+
+set(CMAKE_Fortran_LINK_FLAGS "")

--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -1,0 +1,11 @@
+# Intel Fortan
+
+set(CMAKE_Fortran_FLAGS "-g -traceback")
+
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O -assume realloc_lhs")
+
+set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -fp-model precise")
+
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fpe0 -ftrapuv")
+
+set(CMAKE_Fortran_LINK_FLAGS "")

--- a/nems/util/shr_mpi_mod.F90
+++ b/nems/util/shr_mpi_mod.F90
@@ -92,7 +92,8 @@ Module shr_mpi_mod
        shr_mpi_maxr1
   end interface shr_mpi_max
 
-#include <mpif.h>         ! mpi library include file
+! mpi library include file
+#include <mpif.h>
 
   !===============================================================================
 CONTAINS


### PR DESCRIPTION
### Description of changes

This PR adds cmake build for CMEPS and eliminates a warning with `gfortran`.
- Creates a package configuration that can be used in downstream projects via `find_package(cmeps)`.
- Builds static and shared libraries. Static is default, shared is optional.
- Built library can be linked via `target_link_libraries(target_library cmeps::cmeps)`
- Moves the comment in `nems/util/shr_mpi_mod.F90` after `#include <mpif.h>` one line up.  Macros with comments shows a warning with GNU compilers.

### Specific notes
This is an alternative to the traditional GNUMake.

Are changes expected to change answers?
 - [ ] bit for bit
 - [ ] different at roundoff level
 - [ ] more substantial 

Any User Interface Changes (namelist or namelist defaults changes)?
 - [ ] Yes
 - [x] No

Testing performed if application target is CESM:(either UFS-S2S or CESM testing is required):
No ability to test any of these.
Most likely differences will arise due to different compiler flags.
This will need a bit more tweaks to work with CESM.  It should be doable with assistance.
- [ ] (required) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (required) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-S2S:
Currently S2S uses GNUMake so this is not an issue.
S2S cmake currently does not descend into CMEPS subdirectory, so that is also not an issue.
Ideally, S2S cmake would do `add_subdirectory(CMEPS)` and at that point one would be utilizing this cmake build.
This functionality needs to be tested
- [ ] (required) UFS-S2S testing
   - description:
   - details (e.g. failed tests):

Hashes used for testing:
None of this is tested.
Since this is a PR into `emc/develop`, does CESM build with `emc/develop`?
- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch: nuopc_dev
  - hash:
- [ ] UFS-S2S, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch:
  - hash:
