### PR TITLE
add optional bulk flux calculation 

### DIFF
--- a/mediator/esmFldsExchange_nems_mod.F90
+++ b/mediator/esmFldsExchange_nems_mod.F90
@@ -122,9 +122,9 @@ contains
 
     ! to atm: unmerged from ice
     ! - zonal surface stress, meridional surface stress
-    ! - surface latent heat flux, 
+    ! - surface latent heat flux,
     ! - surface sensible heat flux
-    ! - surface upward longwave heat flux 
+    ! - surface upward longwave heat flux
     ! - evaporation water flux from water
     ! - mean ice volume per unit area
     ! - mean snow volume per unit area
@@ -243,7 +243,7 @@ contains
        end do
        deallocate(flds)
 
-       ! to ocn: long wave net via auto merge 
+       ! to ocn: long wave net via auto merge
        call addfld(fldListTo(compocn)%flds, 'Foxx_lwnet')
        call addfld(fldListFr(compatm)%flds, 'Faxa_lwdn')
        call addmap(fldListFr(compatm)%flds, 'Faxa_lwdn', compocn, maptype, 'none', 'unset')

--- a/mediator/esmFldsExchange_nems_mod.F90
+++ b/mediator/esmFldsExchange_nems_mod.F90
@@ -82,8 +82,9 @@ contains
 
     if ( trim(coupling_mode) == 'nems_orig_data') then
       ! atm and ocn fields required for atm/ocn flux calculation'
-      allocate(flds(6))
-      flds = (/'Sa_u   ','Sa_v   ', 'Sa_z   ', 'Sa_tbot', 'Sa_pbot', 'Sa_shum'/)
+      allocate(flds(10))
+      flds = (/'Sa_u   ','Sa_v   ', 'Sa_z   ', 'Sa_tbot', 'Sa_pbot', 'Sa_shum', &
+               'Sa_u10m','Sa_v10m', 'Sa_t2m ', 'Sa_q2m'/)
       do n = 1,size(flds)
          fldname = trim(flds(n))
          call addfld(fldListFr(compatm)%flds, trim(fldname))

--- a/mediator/fd_nems.yaml
+++ b/mediator/fd_nems.yaml
@@ -157,6 +157,26 @@
        canonical_units: W m-2
        description: atmosphere import - merged ocn/ice flux
      #
+     - standard_name: Sa_u10m
+       alias: inst_zonal_wind_height10m
+       canonical_units: m s-1
+       description: atmosphere export - zonal wind height 10m
+     #
+     - standard_name: Sa_v10m
+       alias: inst_merid_wind_height10m
+       canonical_units: m s-1
+       description: atmosphere export - meridional wind height 10m
+     #
+     - standard_name: Sa_t2m
+       alias: inst_temp_height2m
+       canonical_units: K
+       description: atmosphere export - temperature height 2m
+     #
+     - standard_name: Sa_q2m
+       alias: inst_spec_humid_height2m
+       canonical_units: kg kg -1
+       description: atmosphere export - specifc humidity height 2m
+     #
      #-----------------------------------
      # section: sea-ice export
      #-----------------------------------
@@ -306,7 +326,7 @@
        description: sea-ice export
      #
      - standard_name: Si_u10
-       canonical_units: m
+       canonical_units: m/s
        description: sea-ice export
      #
      - standard_name: Si_vice
@@ -521,10 +541,6 @@
      # section: atmosphere fields that need to be defined but are not used
      #-----------------------------------
      #
-     - standard_name: inst_temp_height2m
-       canonical_units: K
-     - standard_name: inst_spec_humid_height2m
-       canonical_units: K
      - standard_name: inst_down_lw_flx
        canonical_units: W m-2
      - standard_name: inst_net_lw_flx
@@ -551,10 +567,6 @@
        canonical_units: W m-2
      - standard_name: inst_surface_height
        canonical_units: m
-     - standard_name: inst_zonal_wind_height10m
-       canonical_units: m s-1
-     - standard_name: inst_merid_wind_height10m
-       canonical_units: m s-1
      - standard_name: inst_zonal_moment_flx
        canonical_units: N m-2
      - standard_name: inst_merid_moment_flx

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -142,7 +142,7 @@ contains
     use ESMF                  , only : ESMF_SUCCESS, ESMF_FAILURE
     use ESMF                  , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_StateIsCreated
     use ESMF                  , only : ESMF_FieldBundle, ESMF_FieldBundleIsCreated, ESMF_FieldBundleDestroy
-    use ESMF                  , only : ESMF_FieldBundleGet   
+    use ESMF                  , only : ESMF_FieldBundleGet
     use ESMF                  , only : ESMF_Field, ESMF_FieldGet
     use esmFlds               , only : coupling_mode
     use esmFlds               , only : compatm, compocn, compice, complnd
@@ -608,7 +608,7 @@ contains
     ! Update time varying fractions
 
     use ESMF                  , only : ESMF_GridComp, ESMF_GridCompGet
-    use ESMF                  , only : ESMF_Field, ESMF_FieldGet 
+    use ESMF                  , only : ESMF_Field, ESMF_FieldGet
     use ESMF                  , only : ESMF_FieldBundleGet, ESMF_FieldBundleIsCreated
     use ESMF                  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use esmFlds               , only : compatm, compocn, compice, compname

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -49,7 +49,7 @@ module med_internalstate_mod
   end type mesh_info_type
 
   type, public :: packed_data_type
-     integer, allocatable :: fldindex(:) ! size of number of packed fields 
+     integer, allocatable :: fldindex(:) ! size of number of packed fields
      character(len=CS)    :: mapnorm     ! normalization for packed field
      type(ESMF_Field)     :: field_src    ! packed sourced field
      type(ESMF_Field)     :: field_dst    ! packed destination field

--- a/mediator/med_merge_mod.F90
+++ b/mediator/med_merge_mod.F90
@@ -226,8 +226,10 @@ contains
     integer           :: n
     type(ESMF_Field)  :: field_wgt
     type(ESMF_Field)  :: field_in
-    real(R8), pointer :: dp1 (:), dp2(:,:) => null()  ! output pointers to 1d and 2d fields
-    real(R8), pointer :: dpf1(:), dpf2(:,:) => null() ! intput pointers to 1d and 2d fields
+    real(R8), pointer :: dp1 (:) => null()
+    real(R8), pointer :: dp2(:,:) => null()  ! output pointers to 1d and 2d fields
+    real(R8), pointer :: dpf1(:) => null()
+    real(R8), pointer :: dpf2(:,:) => null() ! intput pointers to 1d and 2d fields
     real(R8), pointer :: dpw1(:) => null()            ! weight pointer
     character(len=*),parameter :: subname=' (med_merge_mod: med_merge)'
     !---------------------------------------

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -69,7 +69,6 @@ module med_phases_aofluxes_mod
      real(R8) , pointer :: qref        (:) => null() ! diagnostic:  2m ref Q
      real(R8) , pointer :: u10         (:) => null() ! diagnostic: 10m wind speed
      real(R8) , pointer :: duu10n      (:) => null() ! diagnostic: 10m wind speed squared
-     real(R8) , pointer :: lwdn        (:) => null() ! long  wave, downward
      real(R8) , pointer :: ustar       (:) => null() ! saved ustar
      real(R8) , pointer :: re          (:) => null() ! saved re
      real(R8) , pointer :: ssq         (:) => null() ! saved sq

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -362,9 +362,9 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call FB_GetFldPtr(FBAtm, fldname='Sa_v10m', fldptr1=aoflux%vbot, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       call FB_GetFldPtr(FBAtm, fldname='Sa_tbot', fldptr1=aoflux%tbot, rc=rc)
+       call FB_GetFldPtr(FBAtm, fldname='Sa_t2m', fldptr1=aoflux%tbot, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       call FB_GetFldPtr(FBAtm, fldname='Sa_shum', fldptr1=aoflux%shum, rc=rc)
+       call FB_GetFldPtr(FBAtm, fldname='Sa_q2m', fldptr1=aoflux%shum, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     else
        call FB_GetFldPtr(FBAtm, fldname='Sa_u', fldptr1=aoflux%ubot, rc=rc)

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -232,13 +232,13 @@ contains
     ! get attributes that are set as module variables
     !----------------------------------
 
-    call NUOPC_CompAttributeGet(gcomp, name='flds_wiso', value=cvalue, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
-    read(cvalue,*) flds_wiso
-
-    !----------------------------------
-    ! Get config variables on first call
-    !----------------------------------
+    call NUOPC_CompAttributeGet(gcomp, name='flds_wiso', value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+       read(cvalue,*) flds_wiso
+    else
+       flds_wiso = .false.
+    end if
 
     call NUOPC_CompAttributeGet(gcomp, name='coldair_outbreak_mod', value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -357,7 +357,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! bulk formula quantities for nems_orig_data
-    if (trim(coupling_mode) == 'nems_orig_data' && ocn_surface_flux_scheme == -1)then
+    if (trim(coupling_mode) == 'nems_orig_data' .and. ocn_surface_flux_scheme == -1) then
        call FB_GetFldPtr(FBAtm, fldname='Sa_u10m', fldptr1=aoflux%ubot, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call FB_GetFldPtr(FBAtm, fldname='Sa_v10m', fldptr1=aoflux%vbot, rc=rc)

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -42,7 +42,8 @@ contains
     type(ESMF_Field)           :: lfield
     character(len=64)          :: timestr
     type(InternalState)        :: is_local
-    real(R8), pointer          :: dataPtr1(:),dataPtr2(:) => null()
+    real(R8), pointer          :: dataPtr1(:) => null()
+    real(R8), pointer          :: dataPtr2(:) => null()
     integer                    :: i, j, n, n1, ncnt
     character(len=*),parameter :: subname='(med_phases_prep_atm)'
     !-------------------------------------------------------------------------------

--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -36,7 +36,7 @@ contains
   subroutine med_phases_prep_ice(gcomp, rc)
 
     use ESMF  , only : operator(/=)
-    use ESMF  , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_StateGet 
+    use ESMF  , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_StateGet
     use ESMF  , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF  , only : ESMF_FieldBundleGet, ESMF_FieldGet, ESMF_Field
     use ESMF  , only : ESMF_LOGMSG_ERROR, ESMF_FAILURE
@@ -165,7 +165,7 @@ contains
 
        if (itemType /= ESMF_STATEITEM_NOTFOUND) then
           if (is_local%wrap%flds_scalar_index_nextsw_cday .ne. 0) then
-             ! send nextsw_cday to ice - first obtain it from atm import 
+             ! send nextsw_cday to ice - first obtain it from atm import
              call State_GetScalar(&
                   scalar_value=nextsw_cday, &
                   scalar_id=is_local%wrap%flds_scalar_index_nextsw_cday, &

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -332,18 +332,28 @@ contains
 
     ! local variables
     type(InternalState) :: is_local
-    real(R8), pointer   :: ifrac(:), ofrac(:) => null()
-    real(R8), pointer   :: ifracr(:), ofracr(:) => null()
-    real(R8), pointer   :: avsdr(:), avsdf(:) => null()
-    real(R8), pointer   :: anidr(:), anidf(:) => null()
-    real(R8), pointer   :: Faxa_swvdf(:), Faxa_swndf(:) => null()
-    real(R8), pointer   :: Faxa_swvdr(:), Faxa_swndr(:) => null()
+    real(R8), pointer   :: ifrac(:) => null()
+    real(R8), pointer   :: ofrac(:) => null()
+    real(R8), pointer   :: ifracr(:) => null()
+    real(R8), pointer   :: ofracr(:) => null()
+    real(R8), pointer   :: avsdr(:) => null()
+    real(R8), pointer   :: avsdf(:) => null()
+    real(R8), pointer   :: anidr(:) => null()
+    real(R8), pointer   :: anidf(:) => null()
+    real(R8), pointer   :: Faxa_swvdf(:) => null()
+    real(R8), pointer   :: Faxa_swndf(:) => null()
+    real(R8), pointer   :: Faxa_swvdr(:) => null()
+    real(R8), pointer   :: Faxa_swndr(:) => null()
     real(R8), pointer   :: Foxx_swnet(:) => null()
     real(R8), pointer   :: Foxx_swnet_afracr(:) => null()
-    real(R8), pointer   :: Foxx_swnet_vdr(:), Foxx_swnet_vdf(:) => null()
-    real(R8), pointer   :: Foxx_swnet_idr(:), Foxx_swnet_idf(:) => null()
-    real(R8), pointer   :: Fioi_swpen_vdr(:), Fioi_swpen_vdf(:) => null()
-    real(R8), pointer   :: Fioi_swpen_idr(:), Fioi_swpen_idf(:) => null()
+    real(R8), pointer   :: Foxx_swnet_vdr(:) => null()
+    real(R8), pointer   :: Foxx_swnet_vdf(:) => null()
+    real(R8), pointer   :: Foxx_swnet_idr(:) => null()
+    real(R8), pointer   :: Foxx_swnet_idf(:) => null()
+    real(R8), pointer   :: Fioi_swpen_vdr(:) => null()
+    real(R8), pointer   :: Fioi_swpen_vdf(:) => null()
+    real(R8), pointer   :: Fioi_swpen_idr(:) => null()
+    real(R8), pointer   :: Fioi_swpen_idf(:) => null()
     real(R8), pointer   :: Fioi_swpen(:) => null()
     real(R8), pointer   :: dataptr(:) => null()
     real(R8), pointer   :: dataptr_o(:) => null()
@@ -657,7 +667,7 @@ contains
     end if
 
     ! netsw_for_ocn = [downsw_from_atm*(1-ice_fraction)*(1-ocn_albedo)] + [pensw_from_ice*(ice_fraction)]
-    customwgt(:) = ofrac(:) * (1.0 - 0.06)
+    customwgt(:) = ofrac(:) * (1.0_R8 - 0.06_R8)
     call med_merge_field(is_local%wrap%FBExp(compocn),      'Foxx_swnet_vdr', &
          FBinA=is_local%wrap%FBImp(compatm,compocn), fnameA='Faxa_swvdr'    , wgtA=customwgt, &
          FBinB=is_local%wrap%FBImp(compice,compocn), fnameB='Fioi_swpen_vdr', wgtB=ifrac, rc=rc)

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -356,7 +356,8 @@ contains
     type(ESMF_Mesh)           :: lmesh_lnd
     type(ESMF_Mesh)           :: lmesh_rof
     real(r8), pointer         :: volr_l(:) => null()
-    real(r8), pointer         :: volr_r(:), volr_r_import(:) => null()
+    real(r8), pointer         :: volr_r(:) => null()
+    real(r8), pointer         :: volr_r_import(:) => null()
     real(r8), pointer         :: irrig_normalized_l(:) => null()
     real(r8), pointer         :: irrig_normalized_r(:) => null()
     real(r8), pointer         :: irrig_volr0_l(:) => null()

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -166,7 +166,7 @@ contains
     type(ESMF_Field)          :: field_irrig_flux
     integer                   :: fieldcount
     type(ESMF_Field), pointer :: fieldlist(:) => null()
-    integer                   :: ungriddedUBound(1)     
+    integer                   :: ungriddedUBound(1)
     character(len=*),parameter  :: subname='(med_phases_prep_rof_mod: med_phases_prep_rof_avg)'
     !---------------------------------------
 

--- a/mediator/med_phases_profile_mod.F90
+++ b/mediator/med_phases_profile_mod.F90
@@ -9,7 +9,7 @@ module med_phases_profile_mod
   use med_utils_mod         , only : med_utils_chkerr, med_memcheck
   use med_internalstate_mod , only : mastertask, logunit
   use med_utils_mod         , only : chkerr    => med_utils_ChkErr
-  use med_time_mod          , only : alarmInit => med_time_alarmInit 
+  use med_time_mod          , only : alarmInit => med_time_alarmInit
   use perf_mod              , only : t_startf, t_stopf
   use shr_mem_mod           , only : shr_mem_getusage
 
@@ -38,7 +38,7 @@ contains
     use ESMF  , only : ESMF_TimeSyncToRealTime, ESMF_Time, ESMF_TimeSet
     use ESMF  , only : ESMF_TimeInterval, ESMF_AlarmGet, ESMF_TimeIntervalGet
     use ESMF  , only : ESMF_ClockGetNextTime, ESMF_TimeGet, ESMF_ClockGet
-    use ESMF  , only : ESMF_ClockAdvance, ESMF_ClockSet, ESMF_ClockIsStopTime 
+    use ESMF  , only : ESMF_ClockAdvance, ESMF_ClockSet, ESMF_ClockIsStopTime
     use ESMF  , only : operator(-)
     use NUOPC , only : NUOPC_CompAttributeGet
 
@@ -102,7 +102,7 @@ contains
        call ESMF_ClockSet(clock, currTime=currtime, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       ! intialize 
+       ! intialize
        call ESMF_VMWtime(previous_time, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
 

--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -351,7 +351,7 @@ contains
           endif
 
           ! Write out next ymd/tod in place of curr ymd/tod because the
-          ! restart represents the time at end of the current timestep 
+          ! restart represents the time at end of the current timestep
           ! and that is where we want to start the next run.
 
           call med_io_write(restart_file, iam, start_ymd, 'start_ymd', whead=whead, wdata=wdata, rc=rc)

--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -171,6 +171,7 @@ contains
     character(ESMF_MAXSTR)     :: restart_file   ! Local path to restart filename
     character(ESMF_MAXSTR)     :: restart_pfile  ! Local path to restart pointer filename
     character(ESMF_MAXSTR)     :: cpl_inst_tag   ! instance tag
+    character(ESMF_MAXSTR)     :: restart_dir    ! Optional restart directory name
     character(ESMF_MAXSTR)     :: cvalue         ! attribute string
     character(ESMF_MAXSTR)     :: freq_option    ! freq_option setting (ndays, nsteps, etc)
     integer                    :: freq_n         ! freq_n setting relative to freq_option
@@ -214,6 +215,15 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else
        cpl_inst_tag = ""
+    endif
+
+    call NUOPC_CompAttributeGet(gcomp, name='restart_dir', isPresent=isPresent, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if(isPresent) then
+       call NUOPC_CompAttributeGet(gcomp, name='restart_dir', value=restart_dir, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    else
+       restart_dir = ""
     endif
 
     if (first_time) then
@@ -300,7 +310,8 @@ contains
        ! the timestep and is preferred for restart file names
        !---------------------------------------
 
-       write(restart_file,"(6a)") trim(case_name),'.cpl',trim(cpl_inst_tag),'.r.',trim(nexttimestr),'.nc'
+       write(restart_file,"(6a)") trim(restart_dir)//trim(case_name),'.cpl', &
+         trim(cpl_inst_tag),'.r.',trim(nexttimestr),'.nc'
 
        if (iam == 0) then
           restart_pfile = "rpointer.cpl"//cpl_inst_tag

--- a/nems/util/shr_flux_mod.F90
+++ b/nems/util/shr_flux_mod.F90
@@ -103,22 +103,22 @@ contains
     !--- input arguments --------------------------------
     integer(IN),intent(in) ::       nMax  ! data vector length
     integer(IN),intent(in) :: mask (nMax) ! ocn domain mask       0 <=> out of domain
-    real(R8)   ,intent(in) :: zbot (nMax) ! atm level height      (m)
-    real(R8)   ,intent(in) :: ubot (nMax) ! atm u wind            (m/s)
-    real(R8)   ,intent(in) :: vbot (nMax) ! atm v wind            (m/s)
-    real(R8)   ,intent(in) :: thbot(nMax) ! atm potential T       (K)
-    real(R8)   ,intent(in) :: qbot (nMax) ! atm specific humidity (kg/kg)
-    real(R8)   ,intent(in) :: s16O (nMax) ! atm H216O tracer conc. (kg/kg)
-    real(R8)   ,intent(in) :: sHDO (nMax) ! atm HDO tracer conc.  (kg/kg)
-    real(R8)   ,intent(in) :: s18O (nMax) ! atm H218O tracer conc. (kg/kg)
+    real(R8)   ,intent(in) :: zbot (nMax) ! atm level height                     (m)
+    real(R8)   ,intent(in) :: ubot (nMax) ! atm u wind (bottom or 10m)           (m/s)
+    real(R8)   ,intent(in) :: vbot (nMax) ! atm v wind (bottom or 10m)           (m/s)
+    real(R8)   ,intent(in) :: thbot(nMax) ! atm potential T                      (K)
+    real(R8)   ,intent(in) :: qbot (nMax) ! atm specific humidity (bottom or 2m) (kg/kg)
+    real(R8)   ,intent(in) :: s16O (nMax) ! atm H216O tracer conc.               (kg/kg)
+    real(R8)   ,intent(in) :: sHDO (nMax) ! atm HDO tracer conc.                 (kg/kg)
+    real(R8)   ,intent(in) :: s18O (nMax) ! atm H218O tracer conc.               (kg/kg)
     real(R8)   ,intent(in) :: r16O (nMax) ! ocn H216O tracer ratio/Rstd
     real(R8)   ,intent(in) :: rHDO (nMax) ! ocn HDO tracer ratio/Rstd
     real(R8)   ,intent(in) :: r18O (nMax) ! ocn H218O tracer ratio/Rstd
-    real(R8)   ,intent(in) :: rbot (nMax) ! atm air density       (kg/m^3)
-    real(R8)   ,intent(in) :: tbot (nMax) ! atm T                 (K)
-    real(R8)   ,intent(in) :: us   (nMax) ! ocn u-velocity        (m/s)
-    real(R8)   ,intent(in) :: vs   (nMax) ! ocn v-velocity        (m/s)
-    real(R8)   ,intent(in) :: ts   (nMax) ! ocn temperature       (K)
+    real(R8)   ,intent(in) :: rbot (nMax) ! atm air density                      (kg/m^3)
+    real(R8)   ,intent(in) :: tbot (nMax) ! atm T (bottom or 2m)                 (K)
+    real(R8)   ,intent(in) :: us   (nMax) ! ocn u-velocity                       (m/s)
+    real(R8)   ,intent(in) :: vs   (nMax) ! ocn v-velocity                       (m/s)
+    real(R8)   ,intent(in) :: ts   (nMax) ! ocn temperature                      (K)
     integer(IN),intent(in), optional :: ocn_surface_flux_scheme
     real(R8)   ,intent(in), optional :: seq_flux_atmocn_minwind ! minimum wind speed for atmocn (m/s)
 

--- a/nems/util/shr_flux_mod.F90
+++ b/nems/util/shr_flux_mod.F90
@@ -86,7 +86,7 @@ contains
   end subroutine shr_flux_adjust_constants
 
   !===============================================================================
-  subroutine shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   & 
+  subroutine shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
        &               qbot  ,s16O  ,sHDO  ,s18O  ,rbot  ,   &
        &               tbot  ,us    ,vs    ,   &
        &               ts    ,mask  ,seq_flux_atmocn_minwind, &
@@ -149,7 +149,7 @@ contains
     real(R8),parameter :: zref  = 10.0_R8 ! reference height           (m)
     real(R8),parameter :: ztref =  2.0_R8 ! reference height for air T (m)
     !!++ Large only
-    !real(R8),parameter :: cexcd  = 0.0346_R8 ! ratio Ch(water)/CD 
+    !real(R8),parameter :: cexcd  = 0.0346_R8 ! ratio Ch(water)/CD
     !real(R8),parameter :: chxcds = 0.018_R8  ! ratio Ch(heat)/CD for stable case
     !real(R8),parameter :: chxcdu = 0.0327_R8 ! ratio Ch(heat)/CD for unstable case
     !!++ COARE only
@@ -176,7 +176,7 @@ contains
     real(R8)    :: hol    ! H (at zbot) over L
     real(R8)    :: xsq    ! ?
     real(R8)    :: xqq    ! ?
-    !!++ Large only  
+    !!++ Large only
     real(R8)    :: psimh  ! stability function at zbot (momentum)
     real(R8)    :: psixh  ! stability function at zbot (heat and water)
     real(R8)    :: psix2  ! stability function at ztref reference height
@@ -192,7 +192,6 @@ contains
     real(R8)    :: hsb,hlb         ! sens & lat heat flxs at zbot
     real(R8) :: trf,qrf,urf,vrf ! reference-height quantities
 
-
     !--- local functions --------------------------------
     real(R8)    :: qsat   ! function: the saturation humididty of air (kg/m^3)
     !!++ Large only (formula v*=[c4/U10+c5+c6*U10]*U10 in Large et al. 1994)
@@ -206,7 +205,6 @@ contains
     !--- for cold air outbreak calc --------------------------------
     real(R8)    :: tdiff(nMax)               ! tbot - ts
     real(R8)    :: vscl
-
 
     qsat(Tk)   = 640380.0_R8 / exp(5107.4_R8/Tk)
     cdn(Umps)  =   0.0027_R8 / Umps + 0.000142_R8 + 0.0000764_R8 * Umps
@@ -281,7 +279,7 @@ contains
           !--- neutral coefficients, z/L = 0.0 ---
           stable = 0.5_R8 + sign(0.5_R8 , delt)
           rdn    = sqrt(cdn(vmag))
-          rhn    = (1.0_R8-stable) * 0.0327_R8 + stable * 0.018_R8 
+          rhn    = (1.0_R8-stable) * 0.0327_R8 + stable * 0.018_R8
           !(1.0_R8-stable) * chxcdu + stable * chxcds
           ren    = 0.0346_R8 !cexcd
 

--- a/nems/util/shr_flux_mod.F90
+++ b/nems/util/shr_flux_mod.F90
@@ -249,8 +249,6 @@ contains
     !--- for cold air outbreak calc --------------------------------
     tdiff= tbot - ts
 
-    ! Assume that ocn_surface_flux_scheme = 0 for NEMS
-    ! Default flux scheme.
     al2 = log(zref/ztref)
     DO n=1,nMax
        if (mask(n) /= 0) then

--- a/nems/util/shr_flux_mod.F90
+++ b/nems/util/shr_flux_mod.F90
@@ -304,7 +304,11 @@ contains
 
              !--- shift wind speed using old coefficient ---
              rd   = rdn / (1.0_R8 + rdn/loc_karman*(alz-psimh))
-             u10n = vmag * rd / rdn
+             if (ocn_surface_flux_scheme == -1)then
+                u10n = vmag
+             else
+                u10n = vmag * rd / rdn
+             end if
 
              !--- update transfer coeffs at 10m and neutral stability ---
              rdn = sqrt(cdn(u10n))
@@ -313,7 +317,11 @@ contains
              !(1.0_R8-stable) * chxcdu + stable * chxcds
 
              !--- shift all coeffs to measurement height and stability ---
-             rd = rdn / (1.0_R8 + rdn/loc_karman*(alz-psimh))
+             if (ocn_surface_flux_scheme == -1)then
+               rd = rdn
+             else
+               rd = rdn / (1.0_R8 + rdn/loc_karman*(alz-psimh))
+             end if
              rh = rhn / (1.0_R8 + rhn/loc_karman*(alz-psixh))
              re = ren / (1.0_R8 + ren/loc_karman*(alz-psixh))
 


### PR DESCRIPTION
### Description of changes

An optional bulk flux calculation is added.

### Specific notes

This PR implements a bulk-flux feature in CMEPS  similarly to the version implemented by @hyunchul386 in his [NEMS bulk flux branch](https://github.com/hyunchul386/NEMS/tree/add-1deg-bulk)

In CMEPS, the optional bulk flux method has been implemented with a configuration variable ``ocn_surface_flux_scheme``. For the bulk flux scheme, this variable should be set to -1. A value of 0 will produce the default scheme. 

If the bulk flux configuration is selected, then the fields (``ubot``, ``vbot``, ``tbot``, ``shum``) passed to the shr_flux_mod are the 10m and 2m values. Otherwise, the values passed are the height lowest values.

There are minor differences between the exact implementation in the NEMS mediator vs CMEPS:

- As implemented in CMEPS, the potential temperature and air density passed to the shr_flux_mod are calculated using either the 2m or height_lowest values. In the NEMS mediator, the air density uses the height lowest value for either flux scheme.

- As implemented in CMEPS, the value ``hol`` in the shr_flux_mod will use the value of potential temperature passed in so it will either be calculated at 2m or at height lowest. In the NEMS mediator, the value of ``hol`` was calculated using the potential temperature at the height lowest for either flux scheme.

- In the NEMS mediator, there is an iteration performed in aoflux calculation by re-using a block of code, giving an iteration count of 2. In CMEPS, the number of iterations is set as a configurable variable. Currently it is set as 1. To most closely replicate the NEMS mediator aoflux calculation, this variable should be set to 2 even with the default scheme. Changing the number of iterations will change answers for both the bulk flux option and the default configuration.

- In med_phases_prep_ocn, the temporary variable for 1-oceanalbedo (``customwgt(:) = ofrac(:) * (1.0 - 0.06)``)  is now specified explicitly as R8 (``customwgt(:) = ofrac(:) * (1.0_R8 - 0.06_R8)``). This changes answers for the coupled model. 

CMEPS Issues Fixed (include github issue #):

Issue #20 
Issue #21 

The implementation of the bulk flux can be tested in this [branch](https://github.com/DeniseWorthen/ufs-weather-model/tree/feature/bulk) of ufs-weather-model 
