### PR TITLE
Updated land-sea mask used for CFSR or GEFS data.

### DIFF
--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -258,6 +258,9 @@ contains
        if (n1 == compatm .and. (n2 == compocn .or. n2 == compice)) then
           srcMaskValue = 1
           dstMaskValue = 0
+             if (atm_name(1:9) == 'datm_cfsr' .or. atm_name(1:9) == 'datm_gefs' ) then
+                srcMaskValue = 0
+             endif
        else if (n2 == compatm .and. (n1 == compocn .or. n1 == compice)) then
           srcMaskValue = 0
           dstMaskValue = 1


### PR DESCRIPTION
### Description of changes
The land-sea masks used in CDEPS for CFSR/GEFS data sources are different from those used in NEMS_datm.

### Specific notes
The med_map_mod.F90 file needs to be updated.

CMEPS Issues Fixed: #34 

Are changes expected to change answers?
No