### PR TITLE
add field Sa_ofrac and alias to fd_nems.yaml

### DIFF
--- a/mediator/fd_nems.yaml
+++ b/mediator/fd_nems.yaml
@@ -188,6 +188,11 @@
        canonical_units: W m-2
        description: atmosphere import - merged ocn/ice flux
      #
+     - standard_name: Sa_ofrac
+       alias: openwater_frac_in_atm
+       canonical_units: 1
+       description: atm export to mediator - open water ocean fraction (varies with time)
+     #
      - standard_name: Sa_u10m
        alias: inst_zonal_wind_height10m
        canonical_units: m s-1
@@ -575,7 +580,7 @@
        description:   atmosphere export - latent heat flux conversion
      - alias: Faox_evap
        standard_name : mean_evap_rate
-       description: mediator calculation - atm/ocn specific humidity flux 
+       description: mediator calculation - atm/ocn specific humidity flux
      #
      #-----------------------------------
      # section: atmosphere fields that need to be defined but are not used
@@ -694,8 +699,8 @@
      #-----------------------------------
      #
      - standard_name: sea_surface_height_above_sea_level
-       canonical_units: m 
-       description: ww3 import 
+       canonical_units: m
+       description: ww3 import
      #
      - standard_name: sea_surface_salinity
        alias: s_surf
@@ -705,22 +710,22 @@
      - standard_name: surface_eastward_sea_water_velocity
        alias: ocn_current_zonal
        canonical_units: m s-1
-       description: ww3 import 
+       description: ww3 import
      #
      - standard_name: surface_northward_sea_water_velocity
        alias: ocn_current_merid
        canonical_units: m s-1
-       description: ww3 import 
+       description: ww3 import
      #
      - standard_name: eastward_wind_at_10m_height
        alias: inst_zonal_wind_height10m
        canonical_units: m s-1
-       description: ww3 import 
+       description: ww3 import
      #
      - standard_name: northward_wind_at_10m_height
        alias: inst_merid_wind_height10m
        canonical_units: m s-1
-       description: ww3 import 
+       description: ww3 import
      #
      - standard_name: sea_ice_concentration
        alias: ice_fraction
@@ -732,77 +737,77 @@
      #
      - standard_name: wave_induced_charnock_parameter
        canonical_units: 1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: wave_z0_roughness_length
        canonical_units: 1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: northward_stokes_drift_current
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: eastward_stokes_drift_current
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: eastward_partitioned_stokes_drift_1
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: eastward_partitioned_stokes_drift_2
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: eastward_partitioned_stokes_drift_3
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: northward_partitioned_stokes_drift_1
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: northward_partitioned_stokes_drift_2
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: northward_partitioned_stokes_drift_3
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: eastward_wave_bottom_current
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: northward_wave_bottom_current
        canonical_units: m s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: wave_bottom_current_radian_frequency
        canonical_units: rad s-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: eastward_wave_radiation_stress_gradient
        canonical_units: Pa
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: northward_wave_radiation_stress_gradient
        canonical_units: Pa
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: eastward_wave_radiation_stress
        canonical_units: N m-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: eastward_northward_wave_radiation_stress
        canonical_units: N m-1
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: wave_bottom_current_period
        canonical_units: s
-       description: ww3 export 
+       description: ww3 export
      #
      - standard_name: northward_wave_radiation_stress
        canonical_units: Pa
-       description: ww3 export 
+       description: ww3 export
      #


### PR DESCRIPTION
### Description of changes

Adds field ``Sa_ofrac`` to fd_nems.yaml

### Specific notes

Code changes for the export of Sa_ofrac from ATM can be added to the changes require for the update to bs_47 with no impact to baselines. The field is required to be present in the yaml file when FV3 is updated to include the export of the open water fraction.
