### PR TITLE
use unity normalization; add error catch if more than one normalization type is specified

### DIFF
--- a/mediator/esmFldsExchange_nems_mod.F90
+++ b/mediator/esmFldsExchange_nems_mod.F90
@@ -88,7 +88,7 @@ contains
       do n = 1,size(flds)
          fldname = trim(flds(n))
          call addfld(fldListFr(compatm)%flds, trim(fldname))
-         call addmap(fldListFr(compatm)%flds, trim(fldname), compocn, maptype, 'none', 'unset')
+         call addmap(fldListFr(compatm)%flds, trim(fldname), compocn, maptype, 'one', 'unset')
       end do
       deallocate(flds)
 
@@ -155,7 +155,7 @@ contains
     ! to ocn: sea level pressure from atm
     call addfld(fldListTo(compocn)%flds, 'Sa_pslv')
     call addfld(fldListFr(compatm)%flds, 'Sa_pslv')
-    call addmap(fldListFr(compatm)%flds, 'Sa_pslv', compocn, maptype, 'none', 'unset')
+    call addmap(fldListFr(compatm)%flds, 'Sa_pslv', compocn, maptype, 'one', 'unset')
     call addmrg(fldListTo(compocn)%flds, 'Sa_pslv', mrg_from=compatm, mrg_fld='Sa_pslv', mrg_type='copy')
 
     ! to ocn: from atm (custom merge in med_phases_prep_ocn)
@@ -169,7 +169,7 @@ contains
        fldname = trim(flds(n))
        call addfld(fldListTo(compocn)%flds, trim(fldname))
        call addfld(fldListFr(compatm)%flds, trim(fldname))
-       call addmap(fldListFr(compatm)%flds, trim(fldname), compocn, maptype, 'none', 'unset')
+       call addmap(fldListFr(compatm)%flds, trim(fldname), compocn, maptype, 'one', 'unset')
     end do
     deallocate(flds)
 
@@ -194,7 +194,7 @@ contains
        fldname = trim(flds(n))
        call addfld(fldListTo(compocn)%flds, trim(fldname))
        call addfld(fldListFr(compatm)%flds, trim(fldname))
-       call addmap(fldListFr(compatm)%flds, trim(fldname), compocn, maptype, 'none', 'unset')
+       call addmap(fldListFr(compatm)%flds, trim(fldname), compocn, maptype, 'one', 'unset')
        call addmrg(fldListTo(compocn)%flds, trim(fldname), &
             mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy_with_weights', mrg_fracname='ofrac')
     end do
@@ -208,7 +208,7 @@ contains
           call addfld(fldListTo(compocn)%flds, 'Foxx_'//trim(flds(n)))
           call addfld(fldListFr(compice)%flds, 'Fioi_'//trim(flds(n)))
           call addfld(fldListFr(compatm)%flds, 'Faxa_'//trim(flds(n)))
-          call addmap(fldListFr(compatm)%flds, 'Faxa_'//trim(flds(n)), compocn, maptype, 'none', 'unset')
+          call addmap(fldListFr(compatm)%flds, 'Faxa_'//trim(flds(n)), compocn, maptype, 'one', 'unset')
           call addmap(fldListFr(compice)%flds, 'Fioi_'//trim(flds(n)), compocn, mapfcopy, 'unset', 'unset')
        end do
        deallocate(flds)
@@ -216,20 +216,21 @@ contains
        ! to ocn: net long wave via auto merge
        call addfld(fldListTo(compocn)%flds, 'Faxa_lwnet')
        call addfld(fldListFr(compatm)%flds, 'Faxa_lwnet')
-       call addmap(fldListFr(compatm)%flds, 'Faxa_lwnet', compocn, maptype, 'none', 'unset')
+       call addmap(fldListFr(compatm)%flds, 'Faxa_lwnet', compocn, maptype, 'one', 'unset')
        call addmrg(fldListTo(compocn)%flds, 'Faxa_lwnet', &
             mrg_from=compatm, mrg_fld='Faxa_lwnet', mrg_type='copy_with_weights', mrg_fracname='ofrac')
 
        ! to ocn: merged sensible heat flux (custom merge in med_phases_prep_ocn)
        call addfld(fldListTo(compocn)%flds, 'Faxa_sen')
        call addfld(fldListFr(compatm)%flds, 'Faxa_sen')
-       call addmap(fldListFr(compatm)%flds, 'Faxa_sen', compocn, maptype, 'none', 'unset')
+       call addmap(fldListFr(compatm)%flds, 'Faxa_sen', compocn, maptype, 'one', 'unset')
 
        ! to ocn: evaporation water flux (custom merge in med_phases_prep_ocn)
        call addfld(fldListTo(compocn)%flds, 'Faxa_evap')
        call addfld(fldListFr(compatm)%flds, 'Faxa_lat')
-       call addmap(fldListFr(compatm)%flds, 'Faxa_lat', compocn, maptype, 'none', 'unset')
+       call addmap(fldListFr(compatm)%flds, 'Faxa_lat', compocn, maptype, 'one', 'unset')
     else
+       ! nems_orig_data
        ! to ocn: surface stress from mediator and ice stress via auto merge
        allocate(flds(2))
        flds = (/'taux', 'tauy'/)
@@ -247,7 +248,7 @@ contains
        ! to ocn: long wave net via auto merge
        call addfld(fldListTo(compocn)%flds, 'Foxx_lwnet')
        call addfld(fldListFr(compatm)%flds, 'Faxa_lwdn')
-       call addmap(fldListFr(compatm)%flds, 'Faxa_lwdn', compocn, maptype, 'none', 'unset')
+       call addmap(fldListFr(compatm)%flds, 'Faxa_lwdn', compocn, maptype, 'one', 'unset')
        call addmrg(fldListTo(compocn)%flds, 'Foxx_lwnet', &
              mrg_from=compmed, mrg_fld='Faox_lwup', mrg_type='merge', mrg_fracname='ofrac')
        call addmrg(fldListTo(compocn)%flds, 'Foxx_lwnet', &
@@ -299,7 +300,7 @@ contains
        fldname = trim(flds(n))
        call addfld(fldListFr(compatm)%flds, trim(fldname))
        call addfld(fldListTo(compice)%flds, trim(fldname))
-       call addmap(fldListFr(compatm)%flds, trim(fldname), compice, maptype, 'none', 'unset')
+       call addmap(fldListFr(compatm)%flds, trim(fldname), compice, maptype, 'one', 'unset')
        call addmrg(fldListTo(compice)%flds, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
     end do
     deallocate(flds)
@@ -317,7 +318,7 @@ contains
        fldname = trim(flds(n))
        call addfld(fldListTo(compice)%flds, trim(fldname))
        call addfld(fldListFr(compatm)%flds, trim(fldname))
-       call addmap(fldListFr(compatm)%flds, trim(fldname), compice, maptype, 'none', 'unset')
+       call addmap(fldListFr(compatm)%flds, trim(fldname), compice, maptype, 'one', 'unset')
        call addmrg(fldListTo(compice)%flds, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
     end do
     deallocate(flds)

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -221,7 +221,6 @@ contains
     use esmFlds           , only : mapnstod, mapnstod_consd, mapnstod_consf, mapnstod_consd
     use esmFlds           , only : mapfillv_bilnr, mapbilnr_nstod
     use esmFlds           , only : ncomps, compatm, compice, compocn, compname
-    use esmFlds           , only : mapfcopy, mapconsd, mapconsf, mapnstod
     use esmFlds           , only : coupling_mode, dststatus_print
     use esmFlds           , only : atm_name
     use med_constants_mod , only : ispval_mask => med_constants_ispval_mask
@@ -590,7 +589,6 @@ contains
     ! local variables
     type(InternalState)       :: is_local
     integer                   :: n1, n2, m
-    character(len=1)          :: cn1,cn2,cm
     real(R8), pointer         :: dataptr(:) => null()
     integer                   :: fieldCount
     type(ESMF_Field), pointer :: fieldlist(:) => null()
@@ -661,7 +659,6 @@ contains
                            maptype=m, rc=rc)
                       if (chkerr(rc,__LINE__,u_FILE_u)) return
                       if (mastertask) then
-                         write(cn1,'(i1)') n1; write(cn2,'(i1)') n2; write(cm ,'(i1)') m
                          write(logunit,'(a)') trim(subname)//' created field_NormOne for '&
                               //compname(n1)//'->'//compname(n2)//' with mapping '//mapnames(m)
                       endif
@@ -719,6 +716,8 @@ contains
     type(ESMF_Field), pointer  :: fieldlist_src(:) => null()
     type(ESMF_Field), pointer  :: fieldlist_dst(:) => null()
     character(CL), allocatable :: fieldNameList(:)
+    character(CS)              :: mapnorm_mapindex
+    character(len=CX)          :: tmpstr
     character(len=*), parameter :: subname=' (module_MED_map:med_packed_field_create) '
     !-----------------------------------------------------------
 
@@ -765,6 +764,7 @@ contains
     ! Determine the normalization type for each packed_data mapping element
     ! Loop over mapping types
     do mapindex = 1,nmappers
+       mapnorm_mapindex = 'not_set'
        ! Loop over source field bundle
        do nf = 1, fieldCount
           ! Loop over the fldsSrc types
@@ -776,6 +776,26 @@ contains
                   trim(fldsSrc(ns)%shortname) == trim(fieldnamelist(nf))) then
                 ! Set the normalization to the input
                 packed_data(mapindex)%mapnorm = fldsSrc(ns)%mapnorm(destcomp)
+                if (mapnorm_mapindex == 'not_set') then
+                   mapnorm_mapindex = packed_data(mapindex)%mapnorm
+                   write(tmpstr,*)'Map type '//trim(mapnames(mapindex)) &
+                      //', destcomp '//trim(compname(destcomp)) &
+                      //',  mapnorm '//trim(mapnorm_mapindex) &
+                      //'  '//trim(fieldnamelist(nf))
+                   if (mastertask) write(logunit,*)trim(tmpstr)
+                   call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
+                else
+                   if (mapnorm_mapindex /= packed_data(mapindex)%mapnorm) then
+                     write(tmpstr,*)'Map type '//trim(mapnames(mapindex)) &
+                        //', destcomp '//trim(compname(destcomp)) &
+                        //',  mapnorm '//trim(mapnorm_mapindex) &
+                        //' set; cannot set mapnorm to '//trim(packed_data(mapindex)%mapnorm) &
+                        //'  '//trim(fieldnamelist(nf))
+                     if (mastertask) write(logunit,*)trim(tmpstr)
+                     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
+                     call ESMF_Finalize(endflag=ESMF_END_ABORT)
+                   end if
+                end if
              end if
           end do
        end do

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -782,7 +782,6 @@ contains
                       //', destcomp '//trim(compname(destcomp)) &
                       //',  mapnorm '//trim(mapnorm_mapindex) &
                       //'  '//trim(fieldnamelist(nf))
-                   if (mastertask) write(logunit,*)trim(tmpstr)
                    call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
                 else
                    if (mapnorm_mapindex /= packed_data(mapindex)%mapnorm) then
@@ -791,7 +790,6 @@ contains
                         //',  mapnorm '//trim(mapnorm_mapindex) &
                         //' set; cannot set mapnorm to '//trim(packed_data(mapindex)%mapnorm) &
                         //'  '//trim(fieldnamelist(nf))
-                     if (mastertask) write(logunit,*)trim(tmpstr)
                      call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
                      call ESMF_Finalize(endflag=ESMF_END_ABORT)
                    end if

--- a/mediator/med_phases_ocnalb_mod.F90
+++ b/mediator/med_phases_ocnalb_mod.F90
@@ -573,9 +573,9 @@ contains
     character(len=*) , parameter :: subname = "(med_phases_ocnalb_orbital_update)"
     !-------------------------------------------
 
-#ifdef CESMCOUPLED
     rc = ESMF_SUCCESS
 
+#ifdef CESMCOUPLED
     if (trim(orb_mode) == trim(orb_variable_year)) then
        call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return


### PR DESCRIPTION
Switch to using unityone normalization in ufs for all fields
Add model abort if more than one normalization type is specified for any n1:n2:maptype

CMEPs Issues:

[#38](https://github.com/NOAA-EMC/CMEPS/issues/38)
[#40](https://github.com/NOAA-EMC/CMEPS/issues/40)

### Description of changes

* implements unity normalization by changing normalization type for all fields in ``esmFldsExchange_nems_mod.F90`` from ``none`` to  ``one``
* adds error catch if more than one normalization type is specified for a given map type between two components. For example attempting to set the normalization of Sa_pslv to "none" in this branch produces the following error message in the PET logs.

```
20210415 123018.685 INFO             PET000  Map type consf, destcomp atm,  mapnorm ofrac  So_t
20210415 123018.685 INFO             PET000  Map type consf, destcomp atm,  mapnorm ifrac  Faii_evap
20210415 123018.687 INFO             PET000  Map type consf, destcomp ocn,  mapnorm one  Faxa_lat
20210415 123018.687 INFO             PET000  Map type consf, destcomp ocn,  mapnorm one set; cannot set mapnorm to none  Sa_pslv
20210415 123018.687 INFO             PET000 Finalizing ESMF
```




