### PR TITLE
Update land-sea masks in mediator/med_map_mod.F90.

### DIFF
--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -277,6 +277,9 @@ contains
        if (n1 == compatm .and. (n2 == compocn .or. n2 == compice)) then
           srcMaskValue = 1
           dstMaskValue = 0
+          if (atm_name(1:4).eq.'datm') then
+          srcMaskValue = 0
+          endif
        else if (n2 == compatm .and. (n1 == compocn .or. n1 == compice)) then
           srcMaskValue = 0
           dstMaskValue = 1


### PR DESCRIPTION
### Description of changes

Update "mediator/med_map_mod.F90" to use the correct land-sea masks for cfsr and gefs data sources for the cdeps data atmosphere model.

CMEPS Issues Fixed #42 
