### PR TITLE
add bilnr_nstod mapping between ocn/ice/waves

### DIFF
--- a/mediator/esmFldsExchange_nems_mod.F90
+++ b/mediator/esmFldsExchange_nems_mod.F90
@@ -554,7 +554,7 @@ contains
        else
           if ( fldchk(is_local%wrap%FBexp(compocn)        , trim(fldname), rc=rc) .and. &
                fldchk(is_local%wrap%FBImp(compwav,compwav), trim(fldname), rc=rc)) then
-             call addmap(fldListFr(compwav)%flds, trim(fldname), compocn, mapfcopy, 'unset', 'unset')
+             call addmap(fldListFr(compwav)%flds, trim(fldname), compocn, mapbilnr_nstod, 'one', 'unset')
              call addmrg(fldListTo(compocn)%flds, trim(fldname), mrg_from=compwav, mrg_fld=trim(fldname), mrg_type='copy')
           end if
        end if
@@ -682,7 +682,7 @@ contains
      else
         if ( fldchk(is_local%wrap%FBexp(compwav)        , 'Si_ifrac', rc=rc) .and. &
              fldchk(is_local%wrap%FBImp(compice,compice), 'Si_ifrac', rc=rc)) then
-            call addmap(fldListFr(compice)%flds, 'Si_ifrac', compwav, mapfcopy , 'unset', 'unset')
+            call addmap(fldListFr(compice)%flds, 'Si_ifrac', compwav, mapbilnr_nstod, 'one', 'unset')
             call addmrg(fldListTo(compwav)%flds, 'Si_ifrac', mrg_from=compice, mrg_fld='Si_ifrac', mrg_type='copy')
         end if
      end if
@@ -702,7 +702,7 @@ contains
         else
            if ( fldchk(is_local%wrap%FBexp(compwav)        , trim(fldname), rc=rc) .and. &
                 fldchk(is_local%wrap%FBImp(compocn,compocn), trim(fldname), rc=rc)) then
-              call addmap(fldListFr(compocn)%flds, trim(fldname), compwav, mapfcopy , 'unset', 'unset')
+              call addmap(fldListFr(compocn)%flds, trim(fldname), compwav, mapbilnr_nstod , 'one', 'unset')
               call addmrg(fldListTo(compwav)%flds, trim(fldname), mrg_from=compocn, mrg_fld=trim(fldname), mrg_type='copy')
            end if
         end if

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -410,11 +410,9 @@ contains
     call ESMF_LogWrite(trim(string), ESMF_LOGMSG_INFO)
 
     polemethod=ESMF_POLEMETHOD_ALLAVG
-    if (trim(coupling_mode) == 'cesm') then
-      if (n1 == compwav .or. n2 == compwav) then
-        polemethod = ESMF_POLEMETHOD_NONE ! todo: remove this when ESMF tripolar mapping fix is in place.
-      endif
-    end if
+    if (n1 == compwav .or. n2 == compwav) then
+      polemethod = ESMF_POLEMETHOD_NONE ! todo: remove this when ESMF tripolar mapping fix is in place.
+    endif
 
     ! Create route handle
     if (mapindex == mapfcopy) then

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -410,9 +410,11 @@ contains
     call ESMF_LogWrite(trim(string), ESMF_LOGMSG_INFO)
 
     polemethod=ESMF_POLEMETHOD_ALLAVG
-    if (n1 == compwav .or. n2 == compwav) then
-      polemethod = ESMF_POLEMETHOD_NONE ! todo: remove this when ESMF tripolar mapping fix is in place.
-    endif
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode(1:4)) == 'nems') then
+       if (n1 == compwav .or. n2 == compwav) then
+         polemethod = ESMF_POLEMETHOD_NONE ! todo: remove this when ESMF tripolar mapping fix is in place.
+       endif
+    end if
 
     ! Create route handle
     if (mapindex == mapfcopy) then


### PR DESCRIPTION
### Description of changes

Replaces current 'mapcopy' between ocean/ice and waves with bilinear+nearest neighbor mapping. This allows the wave model to run on a different grid than ocean and ice.




