### PR TITLE
Changes related physics reorganization

### DIFF
--- a/ufs/ccpp/config/ccpp_prebuild_config.py
+++ b/ufs/ccpp/config/ccpp_prebuild_config.py
@@ -25,7 +25,7 @@ HOST_MODEL_IDENTIFIER = "CMEPS"
 VARIABLE_DEFINITION_FILES = [
     # actual variable definition files
     '{}/ccpp/framework/src/ccpp_types.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/machine.F'.format(fv3_path),
+    '{}/ccpp/physics/physics/hooks/machine.F'.format(fv3_path),
     'CMEPS/ufs/ccpp/data/MED_typedefs.F90',
     'CMEPS/ufs/ccpp/data/MED_data.F90'
     ]
@@ -58,13 +58,13 @@ TYPEDEFS_NEW_METADATA = {
 
 # Add all physics scheme files relative to basedir
 SCHEME_FILES = [
-    '{}/ccpp/physics/physics/sfc_ocean.F'.format(fv3_path),
-    '{}/ccpp/physics/physics/sfc_diff.f'.format(fv3_path),
-    '{}/ccpp/physics/physics/GFS_surface_loop_control_part1.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/GFS_surface_loop_control_part2.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/GFS_surface_composites_pre.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/GFS_surface_composites_post.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/sfc_diag.f'.format(fv3_path)
+    '{}/ccpp/physics/physics/SFC_Models/Ocean/UFS/sfc_ocean.F'.format(fv3_path),
+    '{}/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f'.format(fv3_path),
+    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part1.F90'.format(fv3_path),
+    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part2.F90'.format(fv3_path),
+    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.F90'.format(fv3_path),
+    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.F90'.format(fv3_path),
+    '{}/ccpp/physics/physics/SFC_Layer/UFS/sfc_diag.f'.format(fv3_path)
     ]
 
 # Default build dir, relative to current working directory,

--- a/ufs/ccpp/data/MED_typedefs.meta
+++ b/ufs/ccpp/data/MED_typedefs.meta
@@ -1312,7 +1312,7 @@
 [ccpp-table-properties]
   name = MED_typedefs
   type = module
-  relative_path = ../../../../../FV3/ccpp/physics/physics
+  relative_path = ../../../../../FV3/ccpp/physics/physics/hooks
   dependencies = machine.F,physcons.F90
 
 [ccpp-arg-table]


### PR DESCRIPTION
### Description of changes
[The ccpp-physics repository is getting reorganized](https://github.com/ufs-community/ccpp-physics/pull/99), so there are some changes needed to file locations referenced in CMEPS. 
These changes are needed to pass the cpld_control_noaero_p8_agrid UFS regression test 

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

