### PR TITLE
add flag to track lake freezing for clm lake

### DIFF
--- a/ufs/ccpp/data/MED_typedefs.F90
+++ b/ufs/ccpp/data/MED_typedefs.F90
@@ -73,6 +73,7 @@ module MED_typedefs
     real (kind=kind_phys),pointer :: lake_q2m (:)    => null() !< 2 meter humidity from CLM Lake model
     real(kind=kind_phys), pointer :: wind(:)         => null() !< wind speed at lowest model level (m/s)
     logical,              pointer :: flag_iter(:)    => null() !< flag for iteration
+    logical,              pointer :: lake_freeze(:)  => null() !< flag for lake freeze
     real(kind=kind_phys), pointer :: qss_water(:)    => null() !< surface air saturation specific humidity over water (kg/kg)
     real(kind=kind_phys), pointer :: cmm_water(:)    => null() !< momentum exchange coefficient over water (m/s)
     real(kind=kind_phys), pointer :: chh_water(:)    => null() !< thermal exchange coefficient over water (kg/m2s)
@@ -368,6 +369,8 @@ module MED_typedefs
     interstitial%wind = huge
     allocate(interstitial%flag_iter(im))
     interstitial%flag_iter = .true.
+    allocate(interstitial%lake_freeze(im))
+    interstitial%lake_freeze = .false.
     allocate(interstitial%qss_water(im))
     interstitial%qss_water = huge
     allocate(interstitial%cmm_ice(im))
@@ -571,6 +574,7 @@ module MED_typedefs
     interstitial%flag_cice = .false.
     interstitial%flag_guess = .false.
     interstitial%flag_iter = .true.
+    interstitial%lake_freeze = .false.
     interstitial%fm10_ice = huge
     interstitial%fm10_land = huge
     interstitial%fm10_water = huge

--- a/ufs/ccpp/data/MED_typedefs.F90
+++ b/ufs/ccpp/data/MED_typedefs.F90
@@ -73,7 +73,7 @@ module MED_typedefs
     real (kind=kind_phys),pointer :: lake_q2m (:)    => null() !< 2 meter humidity from CLM Lake model
     real(kind=kind_phys), pointer :: wind(:)         => null() !< wind speed at lowest model level (m/s)
     logical,              pointer :: flag_iter(:)    => null() !< flag for iteration
-    logical,              pointer :: lake_freeze(:)  => null() !< flag for lake freeze
+    logical,              pointer :: flag_lakefreeze(:) => null() !< flag for lake freeze
     real(kind=kind_phys), pointer :: qss_water(:)    => null() !< surface air saturation specific humidity over water (kg/kg)
     real(kind=kind_phys), pointer :: cmm_water(:)    => null() !< momentum exchange coefficient over water (m/s)
     real(kind=kind_phys), pointer :: chh_water(:)    => null() !< thermal exchange coefficient over water (kg/m2s)
@@ -369,8 +369,8 @@ module MED_typedefs
     interstitial%wind = huge
     allocate(interstitial%flag_iter(im))
     interstitial%flag_iter = .true.
-    allocate(interstitial%lake_freeze(im))
-    interstitial%lake_freeze = .false.
+    allocate(interstitial%flag_lakefreeze(im))
+    interstitial%flag_lakefreeze = .false.
     allocate(interstitial%qss_water(im))
     interstitial%qss_water = huge
     allocate(interstitial%cmm_ice(im))
@@ -574,7 +574,7 @@ module MED_typedefs
     interstitial%flag_cice = .false.
     interstitial%flag_guess = .false.
     interstitial%flag_iter = .true.
-    interstitial%lake_freeze = .false.
+    interstitial%flag_lakefreeze = .false.
     interstitial%fm10_ice = huge
     interstitial%fm10_land = huge
     interstitial%fm10_water = huge

--- a/ufs/ccpp/data/MED_typedefs.meta
+++ b/ufs/ccpp/data/MED_typedefs.meta
@@ -237,6 +237,12 @@
   units = flag
   dimensions = (horizontal_loop_extent)
   type = logical
+[lake_freeze]
+  standard_name = flag_for_lake_water_freeze
+  long_name = flag for lake water freeze
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
 [qss_water]
   standard_name = surface_specific_humidity_over_water
   long_name = surface air saturation specific humidity over water

--- a/ufs/ccpp/data/MED_typedefs.meta
+++ b/ufs/ccpp/data/MED_typedefs.meta
@@ -237,7 +237,7 @@
   units = flag
   dimensions = (horizontal_loop_extent)
   type = logical
-[lake_freeze]
+[flag_lakefreeze]
   standard_name = flag_for_lake_water_freeze
   long_name = flag for lake water freeze
   units = flag


### PR DESCRIPTION
### Description of changes
A new flag is created to track new freezing lake ice and let sfc_diff to calculate stability variables over the new icy grids for GFS PBL in the second surface loop, which otherwise will remain as missing values.
### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
https://github.com/NOAA-EMC/CMEPS/issues/104
Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
No
Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
No RT baseline changes
