### PR TITLE
Update ccpp-physics in CMEPS to consider sea surface ocean current in air-sea flux computation  

### DIFF
--- a/ufs/ccpp/data/MED_typedefs.F90
+++ b/ufs/ccpp/data/MED_typedefs.F90
@@ -173,6 +173,7 @@ module MED_typedefs
     integer                       :: lsm_noahmp                !< flag for NOAH MP land surface model
     logical                       :: redrag                    !< flag for reduced drag coeff. over sea
     integer                       :: sfc_z0_type               !< surface roughness options over water
+    integer                       :: icplocn2atm               !< flag controlling whether to consider ocean current in air-sea flux calculation 
     logical                       :: thsfc_loc                 !< flag for reference pressure in theta calculation
     integer                       :: nstf_name(5)              !< NSSTM flag: off/uncoupled/coupled=0/1/2
     integer                       :: lkm                       !< 0 = no lake model, 1 = lake model, 2 = lake & nsst on lake points
@@ -249,6 +250,8 @@ module MED_typedefs
     real(kind=kind_phys), pointer :: fice(:)         => null()  !< ice fraction over open water
     real(kind=kind_phys), pointer :: hice(:)         => null()  !< sea ice thickness (m)
     real(kind=kind_phys), pointer :: tsfco(:)        => null()  !< sea surface temperature
+    real(kind=kind_phys), pointer :: usfco(:)        => null()  !< sea surface ocean current (zonal) 
+    real(kind=kind_phys), pointer :: vsfco(:)        => null()  !< sea surface ocean current (merdional)
     real(kind=kind_phys), pointer :: uustar(:)       => null()  !< boundary layer parameter
     real(kind=kind_phys), pointer :: tsfc(:)         => null()  !< surface skin temperature
     real(kind=kind_phys), pointer :: snodi(:)        => null()  !< water equivalent snow depth over ice (mm)
@@ -640,6 +643,7 @@ module MED_typedefs
     model%ivegsrc = 2
     model%redrag = .false.
     model%sfc_z0_type = 0
+    model%icplocn2atm = 0
     model%thsfc_loc = .true.
     model%lsm = 1
     model%lsm_noahmp = 2
@@ -739,6 +743,10 @@ module MED_typedefs
     sfcprop%hice = clear_val
     allocate(sfcprop%tsfco(im))
     sfcprop%tsfco = clear_val
+    allocate(sfcprop%usfco(im))
+    sfcprop%usfco = clear_val
+    allocate(sfcprop%vsfco(im))
+    sfcprop%vsfco = clear_val
     allocate(sfcprop%uustar(im))
     sfcprop%uustar = clear_val
     allocate(sfcprop%tsfc(im))

--- a/ufs/ccpp/data/MED_typedefs.meta
+++ b/ufs/ccpp/data/MED_typedefs.meta
@@ -912,9 +912,9 @@
   dimensions = ()
   type = logical
 [icplocn2atm]
-  standard_name = flag_for_air_sea_flux_computation_over_water
+  standard_name = control_for_air_sea_flux_computation_over_water
   long_name = air-sea flux option
-  units = flag
+  units = 1
   dimensions = ()
   type = integer
 [kdt]
@@ -1163,15 +1163,15 @@
   type = real
   kind = kind_phys
 [usfco]
-  standard_name = ocn_current_zonal
-  long_name = ocn_current_zonal
+  standard_name = x_ocean_current
+  long_name = zonal current at ocean surface
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [vsfco]
-  standard_name = ocn_current_merid
-  long_name = ocn_current_merid
+  standard_name = y_ocean_current
+  long_name = meridional current at ocean surface
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real

--- a/ufs/ccpp/data/MED_typedefs.meta
+++ b/ufs/ccpp/data/MED_typedefs.meta
@@ -911,6 +911,12 @@
   units = flag
   dimensions = ()
   type = logical
+[icplocn2atm]
+  standard_name = flag_for_air_sea_flux_computation_over_water
+  long_name = air-sea flux option
+  units = flag
+  dimensions = ()
+  type = integer
 [kdt]
   standard_name = index_of_timestep
   long_name = current forecast iteration
@@ -1153,6 +1159,20 @@
   standard_name = sea_surface_temperature
   long_name = sea surface temperature
   units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[usfco]
+  standard_name = ocn_current_zonal
+  long_name = ocn_current_zonal
+  units = m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[vsfco]
+  standard_name = ocn_current_merid
+  long_name = ocn_current_merid
+  units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys


### PR DESCRIPTION
### Description of changes
The ccpp-physics has been changed to consider surface ocean current in the air-sea flux calculation. Corresponding changes need to be made in ccpp-physics section of CMEPS.

### Specific notes

Contributors other than yourself, if any:
Co-authored-by @binli2337 ,@BinLiu-NOAA, @WeiguoWang-NOAA, @BijuThomas-NOAA , @hyunsookkim-NOAA ,@XuLi-NOAA, @MariaAristizabal-NOAA, @JohnSteffen-NOAA

CMEPS Issues Fixed #106 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?
No
### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

Tests were made in ufs-weather-model. All tests passed.

