### PR TITLE
allow tiled history files on regional grid

### DIFF
--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -510,7 +510,7 @@ contains
 
 #ifdef CDEPS_INLINE
     !------------------
-    ! phase routine for cdeps inline capabilty 
+    ! phase routine for cdeps inline capabilty
     !------------------
 
     call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_RUN, &
@@ -832,10 +832,10 @@ contains
     if (trim(coupling_mode) == 'cesm') then
        call esmFldsExchange_cesm(gcomp, phase='advertise', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    else if (trim(coupling_mode(1:3)) == 'ufs') then
+    else if (coupling_mode(1:3) == 'ufs') then
        call esmFldsExchange_ufs(gcomp, phase='advertise', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    else if (trim(coupling_mode(1:4)) == 'hafs') then
+    else if (coupling_mode(1:4) == 'hafs') then
        call esmFldsExchange_hafs(gcomp, phase='advertise', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else
@@ -962,7 +962,7 @@ contains
           endif
           if (maintask) then
              write(logunit,*) trim(compname(ncomp))//'_use_data_first_import is ', is_local%wrap%med_data_force_first(ncomp)
-          endif    
+          endif
        end if
     end do
 
@@ -1067,7 +1067,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     !------------------
-    ! Recieve Grids
+    ! Receive Grids
     !------------------
 
     do n1 = 1,ncomps
@@ -1832,7 +1832,7 @@ contains
       if (trim(coupling_mode) == 'cesm') then
          call esmFldsExchange_cesm(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      else if (trim(coupling_mode(1:3)) == 'ufs') then
+      else if (coupling_mode(1:3) == 'ufs') then
          call esmFldsExchange_ufs(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else if (coupling_mode(1:4) == 'hafs') then

--- a/mediator/med_fraction_mod.F90
+++ b/mediator/med_fraction_mod.F90
@@ -293,7 +293,7 @@ contains
           ! If ice and atm are on the same mesh - a redist route handle has already been created
           maptype = mapfcopy
        else
-          if (trim(coupling_mode(1:9)) == 'ufs.nfrac' ) then
+          if (coupling_mode(1:9) == 'ufs.nfrac' ) then
              maptype = mapnstod_consd
           else
              maptype = mapconsd
@@ -345,7 +345,7 @@ contains
           ! If ocn and atm are on the same mesh - a redist route handle has already been created
           maptype = mapfcopy
        else
-          if (trim(coupling_mode(1:9)) == 'ufs.nfrac' ) then
+          if (coupling_mode(1:9) == 'ufs.nfrac' ) then
              maptype = mapnstod_consd
           else
              maptype = mapconsd
@@ -756,7 +756,7 @@ contains
 
           call t_startf('MED:'//trim(subname)//' fbfrac(compatm)')
           ! Determine maptype
-          if (trim(coupling_mode(1:9)) == 'ufs.nfrac' ) then
+          if (coupling_mode(1:9) == 'ufs.nfrac' ) then
              maptype = mapnstod_consd
           else
              if (med_map_RH_is_created(is_local%wrap%RH(compice,compatm,:),mapfcopy, rc=rc)) then

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -121,7 +121,7 @@ module med_internalstate_mod
     ! Present/allowed coupling/active coupling logical flags
     logical, pointer :: comp_present(:)               ! comp present flag
     logical, pointer :: med_coupling_active(:,:)      ! computes the active coupling
-    logical, pointer :: med_data_active(:,:)          ! uses stream data to provide background fill 
+    logical, pointer :: med_data_active(:,:)          ! uses stream data to provide background fill
     logical, pointer :: med_data_force_first(:)       ! force to use stream data for first coupling timestep
     integer          :: num_icesheets                 ! obtained from attribute
     logical          :: ocn2glc_coupling = .false.    ! obtained from attribute
@@ -601,7 +601,7 @@ contains
     if (is_local%wrap%comp_present(compocn)) defaultMasks(compocn,:) = 0
     if (is_local%wrap%comp_present(compice)) defaultMasks(compice,:) = 0
     if (is_local%wrap%comp_present(compwav)) defaultMasks(compwav,:) = 0
-    if ( trim(coupling_mode(1:3)) == 'ufs') then
+    if ( coupling_mode(1:3) == 'ufs') then
        if (is_local%wrap%comp_present(compatm)) defaultMasks(compatm,:) = 1
     endif
     if ( trim(coupling_mode) == 'hafs') then

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -728,7 +728,7 @@ contains
     character(len=*), optional , intent(in) :: flds(:)   ! specific fields to write out
     logical,          optional , intent(in) :: tavg      ! is this a tavg
     logical,          optional , intent(in) :: use_float ! write output as float rather than double
-    integer,          optional , intent(in) :: tilesize  ! if non-zero, write atm component on tiles
+    integer,          optional , intent(in) :: tilesize(3) ! if first element is non-zero, write component history on tiles
     integer                    , intent(out):: rc
 
     ! local variables
@@ -770,7 +770,7 @@ contains
     integer                       :: rank
     integer                       :: ungriddedUBound(1) ! currently the size must equal 1 for rank 2 fields
     integer                       :: gridToFieldMap(1)  ! currently the size must equal 1 for rank 2 fields
-    logical                       :: atmtiles
+    logical                       :: comptiles
     integer                       :: ntiles = 1
     character(CL), allocatable    :: fieldNameList(:)
     character(*),parameter :: subName = '(med_io_write_FB) '
@@ -785,9 +785,9 @@ contains
     luse_float = .false.
     if (present(use_float)) luse_float = use_float
 
-    atmtiles = .false.
+    comptiles = .false.
     if (present(tilesize)) then
-      if (tilesize > 0) atmtiles = .true.
+      if (tilesize(1) > 0) comptiles = .true.
     end if
 
     ! Error check
@@ -870,14 +870,14 @@ contains
     ! all the global grid values in the distgrid - e.g. CTSM
 
     ng = maxval(maxIndexPTile)
-    if (atmtiles) then
-      lnx = tilesize
-      lny = tilesize
-      ntiles = ng/(lnx*lny)
+    if (comptiles) then
+       ntiles = tilesize(1)
+       lnx = tilesize(2)
+       lny = tilesize(3)
       write(tmpstr,*) subname, 'ng,lnx,lny,ntiles = ',ng,lnx,lny,ntiles
       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
-      if (ntiles /= 6) then
-         call ESMF_LogWrite(trim(subname)//' ERROR: only cubed sphere atm tiles valid ', ESMF_LOGMSG_INFO)
+       if (ntiles*lnx*lny /= ng) then
+          call ESMF_LogWrite(trim(subname)//' ERROR: component tile sizes are not consistent ', ESMF_LOGMSG_INFO)
          call ESMF_Finalize(endflag=ESMF_END_ABORT)
       endif
     else
@@ -900,7 +900,7 @@ contains
 
     ! Write header
     if (whead) then
-      if (atmtiles) then
+      if (comptiles) then
        rcode = pio_def_dim(io_file, trim(lpre)//'_nx', lnx, dimid3(1))
        rcode = pio_def_dim(io_file, trim(lpre)//'_ny', lny, dimid3(2))
        rcode = pio_def_dim(io_file, trim(lpre)//'_ntiles', ntiles, dimid3(3))
@@ -1020,7 +1020,7 @@ contains
        call ESMF_DistGridGet(distgrid, localDE=0, seqIndexList=dof, rc=rc)
        write(tmpstr,*) subname,' dof = ',ns,size(dof),dof(1),dof(ns)  !,minval(dof),maxval(dof)
        call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO)
-       if (atmtiles) then
+       if (comptiles) then
           call pio_initdecomp(io_subsystem, pio_double, (/lnx,lny,ntiles/), dof, iodesc)
        else
           call pio_initdecomp(io_subsystem, pio_double, (/lnx,lny/), dof, iodesc)
@@ -1579,8 +1579,8 @@ contains
           allocate(fldptr1_tmp(lsize))
 
           do n = 1,ungriddedUBound(1)
-             ! Creat a name for the 1d field on the mediator history or restart file based on the
-             ! ungridded dimension index of the field bundle 2d fiedl
+             ! Create a name for the 1d field on the mediator history or restart file based on the
+             ! ungridded dimension index of the field bundle 2d field
              write(cnumber,'(i0)') n
              name1 = trim(lpre)//'_'//trim(itemc)//trim(cnumber)
 

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -408,7 +408,7 @@ contains
          dstMaskValue = ispval_mask
       endif
     end if
-    if (trim(coupling_mode(1:3)) == 'ufs') then
+    if (coupling_mode(1:3) == 'ufs') then
        if (n1 == compatm .and. n2 == complnd) then
           srcMaskValue = ispval_mask
           dstMaskValue = ispval_mask
@@ -424,7 +424,7 @@ contains
     call ESMF_LogWrite(trim(string), ESMF_LOGMSG_INFO)
 
     polemethod=ESMF_POLEMETHOD_ALLAVG
-    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode(1:3)) == 'ufs') then
+    if (trim(coupling_mode) == 'cesm' .or. coupling_mode(1:3) == 'ufs') then
        if (n1 == compwav .or. n2 == compwav) then
          polemethod = ESMF_POLEMETHOD_NONE ! todo: remove this when ESMF tripolar mapping fix is in place.
        endif
@@ -949,7 +949,7 @@ contains
     type(ESMF_FieldBundle)          , intent(in)    :: FBFracSrc         ! fraction field bundle for source
     type(packed_data_type)          , intent(inout) :: packed_data(:)    ! array over mapping types
     type(ESMF_RouteHandle)          , intent(inout) :: routehandles(:)
-    type(ESMF_FieldBundle), optional, intent(in)    :: FBDat             ! data field bundle 
+    type(ESMF_FieldBundle), optional, intent(in)    :: FBDat             ! data field bundle
     logical, optional               , intent(in)    :: use_data          ! skip mapping and use data instead
     integer, optional               , intent(out)   :: rc
 
@@ -1008,7 +1008,7 @@ contains
           allocate(field_namelist_dat(fieldcount_dat))
           call ESMF_FieldBundleGet(FBDat, fieldlist=fieldlist_dat, fieldNameList=field_namelist_dat, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          
+
           if (present(use_data)) skip_mapping = use_data
        end if
     end if
@@ -1072,7 +1072,7 @@ contains
              call t_stopf('MED:'//trim(subname)//' copy from src')
 
              ! -----------------------------------
-             ! Fill destination field with background data provided by CDEPS inline 
+             ! Fill destination field with background data provided by CDEPS inline
              ! -----------------------------------
 
              if (fieldcount_dat > 0) then
@@ -1085,52 +1085,52 @@ contains
                    ! Get the indices into the packed data structure
                    np = packed_data(mapindex)%fldindex(nf)
                    if (np > 0) then
-                     ! Get size of ungridded dimension and name of the field
-                     call ESMF_FieldGet(fieldlist_dst(nf), ungriddedUBound=ungriddedUBound, name=field_name, rc=rc)
-                     if (chkerr(rc,__LINE__,u_FILE_u)) return
+                      ! Get size of ungridded dimension and name of the field
+                      call ESMF_FieldGet(fieldlist_dst(nf), ungriddedUBound=ungriddedUBound, name=field_name, rc=rc)
+                      if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-                     if (maintask) write(logunit,'(a)') trim(subname)//" search "//trim(field_name)//" field for background fill."
+                      if (maintask) write(logunit,'(a)') trim(subname)//" search "//trim(field_name)//" field for background fill."
 
-                     ! Check if field has match in data fields
-                     isFound = .false.
-                     do nfd = 1, fieldcount_dat
-                        ! Debug output for checked fields to find match
-                        if (maintask .and. dbug_flag > 1) write(logunit,'(a)') trim(field_name)//" - "//trim(field_namelist_dat(nfd))
+                      ! Check if field has match in data fields
+                      isFound = .false.
+                      do nfd = 1, fieldcount_dat
+                         ! Debug output for checked fields to find match
+                         if (maintask .and. dbug_flag > 1) write(logunit,'(a)') trim(field_name)//" - "//trim(field_namelist_dat(nfd))
 
-                        if (trim(field_name) == trim(field_namelist_dat(nfd))) then
-                           ! Debug output about match
-                           if (maintask) write(logunit,'(a)') trim(subname)//" field "//trim(field_namelist_dat(nfd))//" is found!"
-                           
-                           ! Get pointer from data field
-                           call ESMF_FieldGet(fieldlist_dat(nfd), farrayptr=dataptr, rc=rc)
-                           if (chkerr(rc,__LINE__,u_FILE_u)) return
+                         if (trim(field_name) == trim(field_namelist_dat(nfd))) then
+                            ! Debug output about match
+                            if (maintask) write(logunit,'(a)') trim(subname)//" field "//trim(field_namelist_dat(nfd))//" is found!"
 
-                           if (dbug_flag > 1) then
-                              call Field_diagnose(packed_data(mapindex)%field_dst, trim(field_name), " --> before background fill: ", rc=rc)
-                              if (chkerr(rc,__LINE__,u_FILE_u)) return
-                           end if
+                            ! Get pointer from data field
+                            call ESMF_FieldGet(fieldlist_dat(nfd), farrayptr=dataptr, rc=rc)
+                            if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-                           ! Fill destination field with background data coming from stream
-                           dataptr2d_packed(np,:) = dataptr(:)
+                            if (dbug_flag > 1) then
+                               call Field_diagnose(packed_data(mapindex)%field_dst, trim(field_name), " --> before background fill: ", rc=rc)
+                               if (chkerr(rc,__LINE__,u_FILE_u)) return
+                            end if
 
-                           if (dbug_flag > 1) then
-                              call Field_diagnose(packed_data(mapindex)%field_dst, trim(field_name), " --> after  background fill: ", rc=rc)
-                              if (chkerr(rc,__LINE__,u_FILE_u)) return
-                           end if
+                            ! Fill destination field with background data coming from stream
+                            dataptr2d_packed(np,:) = dataptr(:)
 
-                           ! Exit from loop since match is already found
-                           isFound = .true.
-                           exit
-                        end if
-                     end do ! loop for stream fields
+                            if (dbug_flag > 1) then
+                               call Field_diagnose(packed_data(mapindex)%field_dst, trim(field_name), " --> after  background fill: ", rc=rc)
+                               if (chkerr(rc,__LINE__,u_FILE_u)) return
+                            end if
 
-                     ! Could not find match in the list of stream fields
-                     if (.not. isFound) then
-                        if (maintask) write(logunit,'(a)') trim(subname)//" field "//trim(field_name)//" is not found!"
+                            ! Exit from loop since match is already found
+                            isFound = .true.
+                            exit
+                         end if
+                      end do ! loop for stream fields
 
-                        ! Fill destination field with very large background data
-                        dataptr2d_packed(np,:) = fillValue
-                     end if
+                      ! Could not find match in the list of stream fields
+                      if (.not. isFound) then
+                         if (maintask) write(logunit,'(a)') trim(subname)//" field "//trim(field_name)//" is not found!"
+
+                         ! Fill destination field with very large background data
+                         dataptr2d_packed(np,:) = fillValue
+                      end if
                    end if
                 end do ! loop for destination fields
 

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -672,7 +672,7 @@ contains
     integer             :: hist_n       ! freq_n setting relative to freq_option
     character(CL)       :: hist_option_in
     character(CL)       :: hist_n_in
-    integer             :: hist_tilesize
+    integer             :: hist_tilesize(3) ! number of tiles, tile xdim, tile ydim
     logical             :: isPresent
     logical             :: isSet
     type(ESMF_VM)       :: vm
@@ -700,7 +700,7 @@ contains
     if (isPresent .and. isSet) then
        call NUOPC_CompAttributeGet(gcomp, name='history_tile_'//trim(compname(compid)), value=cvalue, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       read(cvalue,*) hist_tilesize
+       read(cvalue,*) hist_tilesize(1:3)
     else
        hist_tilesize = 0
     end if
@@ -830,7 +830,7 @@ contains
     integer                 :: hist_n        ! freq_n setting relative to freq_option
     character(CL)           :: hist_option_in
     character(CL)           :: hist_n_in
-    integer                 :: hist_tilesize
+    integer                 :: hist_tilesize(3) ! number of tiles, tile xdim, tile ydim
     logical                 :: isPresent
     logical                 :: isSet
     type(ESMF_VM)           :: vm
@@ -860,7 +860,7 @@ contains
     if (isPresent .and. isSet) then
        call NUOPC_CompAttributeGet(gcomp, name='history_tile_'//trim(compname(compid)), value=cvalue, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       read(cvalue,*) hist_tilesize
+       read(cvalue,*) hist_tilesize(1:3)
     else
        hist_tilesize = 0
     end if

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -172,6 +172,7 @@ contains
     integer                 :: m,n        ! indices
     character(CL)           :: time_units   ! units of time variable
     character(CL)           :: hist_file    ! history file name
+    integer                 :: hist_tilesize(ncomps,3) ! number of tiles, tile xdim, tile ydim
     real(r8)                :: time_val     ! time coordinate output
     real(r8)                :: time_bnds(2) ! time bounds output
     logical                 :: write_now    ! true => write to history type
@@ -206,6 +207,19 @@ contains
           call NUOPC_CompAttributeGet(gcomp, name='history_n', value=cvalue, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           read(cvalue,*) hist_n_all_inst
+
+          do n = 2,ncomps ! skip the mediator here
+             ! Determine if tiled output to history file is requested for any component
+             call NUOPC_CompAttributeGet(gcomp, name='history_tile_'//trim(compname(n), isPresent=isPresent, isSet=isSet, rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+             if (isPresent .and. isSet) then
+                call NUOPC_CompAttributeGet(gcomp, name='history_tile_'//trim(compname(n)), value=cvalue, rc=rc)
+                if (ChkErr(rc,__LINE__,u_FILE_u)) return
+                read(cvalue,*) hist_tilesize(n,1:3)
+             else
+                hist_tilesize(n,:) = 0
+             end if
+          end do
        else
           ! If attribute is not present - don't write history output
           hist_option_all_inst = 'none'
@@ -322,12 +336,14 @@ contains
                 if (is_local%wrap%comp_present(n)) then
                    if (ESMF_FieldBundleIsCreated(is_local%wrap%FBimp(n,n),rc=rc)) then
                       call med_io_write(io_file, is_local%wrap%FBimp(n,n), whead(m), wdata(m), &
-                           is_local%wrap%nx(n), is_local%wrap%ny(n), nt=1, pre=trim(compname(n))//'Imp', rc=rc)
+                           is_local%wrap%nx(n), is_local%wrap%ny(n), nt=1, pre=trim(compname(n))//'Imp', &
+                           tilesize=hist_tilesize(n,:), rc=rc)
                       if (ChkErr(rc,__LINE__,u_FILE_u)) return
                    endif
                    if (ESMF_FieldBundleIsCreated(is_local%wrap%FBexp(n),rc=rc)) then
                       call med_io_write(io_file, is_local%wrap%FBexp(n), whead(m), wdata(m), &
-                           is_local%wrap%nx(n), is_local%wrap%ny(n), nt=1, pre=trim(compname(n))//'Exp', rc=rc)
+                           is_local%wrap%nx(n), is_local%wrap%ny(n), nt=1, pre=trim(compname(n))//'Exp', &
+                           tilesize=hist_tilesize(n,:), rc=rc)
                       if (ChkErr(rc,__LINE__,u_FILE_u)) return
                    endif
                 end if

--- a/ufs/glc_elevclass_mod.F90
+++ b/ufs/glc_elevclass_mod.F90
@@ -37,6 +37,7 @@ contains
     real(r8), intent(in)  :: glc_topo(:)      ! topographic height
     integer , intent(out) :: glc_elevclass(:) ! elevation class
     integer , intent(in)  :: logunit
+    glc_elevclass = 0
   end subroutine glc_get_elevation_classes_without_bareland
 
   !-----------------------------------------------------------------------
@@ -45,6 +46,7 @@ contains
     real(r8), intent(in)  :: glc_topo(:)        ! ice topographic height
     integer , intent(out) :: glc_elevclass(:)   ! elevation class
     integer , intent(in)  :: logunit
+    glc_elevclass = 0
   end subroutine glc_get_elevation_classes_with_bareland
 
   !-----------------------------------------------------------------------
@@ -57,11 +59,12 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine glc_get_fractional_icecov(nec, glc_topo, glc_icefrac, glc_icefrac_ec, logunit)
-    integer , intent(in)  :: nec              ! number of elevation classes 
+    integer , intent(in)  :: nec              ! number of elevation classes
     real(r8), intent(in)  :: glc_topo(:)      ! topographic height
     real(r8), intent(in)  :: glc_icefrac(:)
     real(r8), intent(out) :: glc_icefrac_ec(:,:)
     integer , intent(in)  :: logunit
+    glc_icefrac_ec = 0.0_r8
   end subroutine glc_get_fractional_icecov
 
 end module glc_elevclass_mod


### PR DESCRIPTION
### Description of changes

Allows tiled history files to be on a single tile.
Removes unnecessary trim statements.
Gives an explicit to variables in the ufs/glc_elevclass_mod.F90

- fixes #111 
- resolves UWM Issue https://github.com/ufs-community/ufs-weather-model/issues/1984 for the CMEPS component
