### PR TITLE
Bugfix: update data type for use_2m_diagnostics_calculated_by_lake_model

### DIFF
--- a/ufs/ccpp/data/MED_typedefs.meta
+++ b/ufs/ccpp/data/MED_typedefs.meta
@@ -862,7 +862,7 @@
   long_name = model 2m diagnostics use the temperature and humidity calculated by the lake model
   units = flag
   dimensions = ()
-  type = integer
+  type = logical
 [lkm]
   standard_name = control_for_lake_model_execution_method
   long_name = control for lake model execution: 0=no lake, 1=lake, 2=lake+nsst


### PR DESCRIPTION
### Description of changes

Fix the data type of one variable in MED_typedefs.meta. There was an error in the data type used in the physics and all host metadata. The datatype is LOGICAL in the actual FORTRAN code, but was listed as INTEGER in the metadata. This bug was fixed because the new version of the CCPP Framework actually compares metadata to the FORTRAN code.

Change is analogous to https://github.com/NOAA-EMC/fv3atm/pull/831

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): None

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Should be B4B. This is only a metadata change.

Any User Interface Changes (namelist or namelist defaults changes)? 

No

### Testing performed
Testing will be reported on in https://github.com/ufs-community/ufs-weather-model/pull/2264

