### PR TITLE
Flexible restart write times (restart_fh)

### DIFF
--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -14,6 +14,9 @@ module med_phases_restart_mod
   use med_phases_prep_glc_mod , only : FBocnAccum2glc_o, ocnAccum2glc_cnt
   use med_phases_prep_rof_mod , only : FBlndAccum2rof_l, lndAccum2rof_cnt
   use pio                     , only : file_desc_t
+#ifndef CESMCOUPLED
+  use shr_is_restart_fh_mod, only : init_is_restart_fh, is_restart_fh, write_restartfh
+#endif
   implicit none
   private
 
@@ -114,6 +117,10 @@ contains
        write(logunit,'(a,l7)') trim(subname)//" write_restart_at_endofrun : ", write_restart_at_endofrun
        write(logunit,*)
     end if
+
+#ifndef CESMCOUPLED
+    call init_is_restart_fh(mcurrtime, timestep_length,maintask)
+#endif
 
   end subroutine med_phases_restart_alarm_init
 
@@ -243,6 +250,11 @@ contains
           AlarmIsOn = .false.
        endif
     endif
+
+#ifndef CESMCOUPLED
+    write_restartfh = is_restart_fh(clock)
+    if (write_restartfh) alarmIsOn = .true.
+#endif
 
     if (alarmIsOn) then
        call ESMF_ClockGet(clock, currtime=currtime, starttime=starttime, rc=rc)

--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -15,7 +15,7 @@ module med_phases_restart_mod
   use med_phases_prep_rof_mod , only : FBlndAccum2rof_l, lndAccum2rof_cnt
   use pio                     , only : file_desc_t
 #ifndef CESMCOUPLED
-  use shr_is_restart_fh_mod, only : init_is_restart_fh, is_restart_fh, write_restartfh
+  use shr_is_restart_fh_mod, only : init_is_restart_fh, is_restart_fh, is_restart_fh_type
 #endif
   implicit none
   private
@@ -26,6 +26,9 @@ module med_phases_restart_mod
   private :: med_phases_restart_alarm_init
 
   logical :: write_restart_at_endofrun = .false.
+#ifndef CESMCOUPLED
+  type(is_restart_fh_type) :: restartfh_info ! For flexible restarts in UFS
+#endif
   logical :: whead(2) = (/.true. , .false./)
   logical :: wdata(2) = (/.false., .true. /)
 
@@ -119,7 +122,7 @@ contains
     end if
 
 #ifndef CESMCOUPLED
-    call init_is_restart_fh(mcurrtime, timestep_length,maintask)
+    call init_is_restart_fh(mcurrtime, timestep_length,maintask, restartfh_info)
 #endif
 
   end subroutine med_phases_restart_alarm_init
@@ -185,6 +188,7 @@ contains
     real(R8)                   :: tbnds(2)       ! CF1.0 time bounds
     logical                    :: isPresent
     logical                    :: first_time = .true.
+    logical                    :: write_restartfh
     character(len=*), parameter :: subname='(med_phases_restart_write)'
     !---------------------------------------
 
@@ -252,7 +256,7 @@ contains
     endif
 
 #ifndef CESMCOUPLED
-    write_restartfh = is_restart_fh(clock)
+    call is_restart_fh(clock, restartfh_info, write_restartfh)
     if (write_restartfh) alarmIsOn = .true.
 #endif
 


### PR DESCRIPTION
### Description of changes
This PR enables writing forecast hour defined restarts ("restart_fh") in the same way as space-delimited floating point forecast hours in model_configure attributes, like `restart_fh: 0.25 2.5 6 17 24`. The implementation builds on [current restart_fh in MOM6](https://github.com/ufs-community/ufs-weather-model/pull/2099) for CMEPS, MOM6, CICE, and WW3 to have option of forecast hour restarts in addition to existing functionality. Restart writes are triggered when input restart_fh forecast hours are evenly divisible by a component's timestep (internally compared in units of integer seconds) and skipped otherwise.

### Specific notes

Contributors other than yourself, if any: Denise Worthen, Jun Wang

CMEPS Issues Fixed (include github issue #): https://github.com/ufs-community/ufs-weather-model/issues/2348

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) bfb

Any User Interface Changes (namelist or namelist defaults changes)? Optional enabling in UFS configure component attribute

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

Testing with cpld_control_gfsv17 confirms that restarts are b4b when (1) sharing common times with RESTART_N and (2) instead of RESTART_N. This feature is exercised in ufs-weather-model regression testing (see https://github.com/ufs-community/ufs-weather-model/pull/2419)