### PR TITLE
if maintask call log_restart_fh

### DIFF
--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -492,8 +492,10 @@ contains
        call med_io_close(io_file, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 #ifndef CESMCOUPLED
-       call log_restart_fh(nextTime, startTime, 'cmeps', rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (maintask) then
+         call log_restart_fh(nextTime, startTime, 'cmeps', rc=rc)
+         if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       endif
 #endif
     endif
 


### PR DESCRIPTION
### Description of changes
So different tasks aren't opening and closing same filename, if maintask call log_restart_fh

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #): https://github.com/NOAA-EMC/CMEPS/issues/144

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

ufs-weather-model RTs on hera. See https://github.com/ufs-community/ufs-weather-model/pull/2777
