### PR TITLE
FV3 -> UFSATM name change.

### DIFF
--- a/mediator/esmFldsExchange_ufs_mod.F90
+++ b/mediator/esmFldsExchange_ufs_mod.F90
@@ -312,7 +312,7 @@ contains
        deallocate(flds)
     end if
 
-    ! to atm: unmerged from mediator, merge will be done under FV3/CCPP composite step
+    ! to atm: unmerged from mediator, merge will be done under UFSATM/CCPP composite step
     ! - zonal surface stress, meridional surface stress
     ! - surface latent heat flux,
     ! - surface sensible heat flux

--- a/ufs/ccpp/config/ccpp_prebuild_config.py
+++ b/ufs/ccpp/config/ccpp_prebuild_config.py
@@ -10,7 +10,7 @@ import os
 # Query required information/s                                                 #
 ###############################################################################
 
-UFSATM_path = os.environ['UFSATM_PATH']
+ufsatm_path = os.environ['UFSATM_PATH']
 
 ###############################################################################
 # Definitions                                                                 #
@@ -61,7 +61,7 @@ SCHEME_FILES = [
     '{}/ccpp/physics/physics/SFC_Models/Ocean/UFS/sfc_ocean.F'.format(ufsatm_path),
     '{}/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f'.format(ufsatm_path),
     '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part1.F90'.format(ufsatm_path),
-    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part2.F90'.format(_path),
+    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part2.F90'.format(ufsatm_path),
     '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.F90'.format(ufsatm_path),
     '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.F90'.format(ufsatm_path),
     '{}/ccpp/physics/physics/SFC_Layer/UFS/sfc_diag.f'.format(ufsatm_path)

--- a/ufs/ccpp/config/ccpp_prebuild_config.py
+++ b/ufs/ccpp/config/ccpp_prebuild_config.py
@@ -10,7 +10,7 @@ import os
 # Query required information/s                                                 #
 ###############################################################################
 
-fv3_path = os.environ['FV3_PATH']
+UFSATM_path = os.environ['UFSATM_PATH']
 
 ###############################################################################
 # Definitions                                                                 #
@@ -24,8 +24,8 @@ HOST_MODEL_IDENTIFIER = "CMEPS"
 # dependencies of these files to the list.
 VARIABLE_DEFINITION_FILES = [
     # actual variable definition files
-    '{}/ccpp/framework/src/ccpp_types.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/hooks/machine.F'.format(fv3_path),
+    '{}/ccpp/framework/src/ccpp_types.F90'.format(ufsatm_path),
+    '{}/ccpp/physics/physics/hooks/machine.F'.format(ufsatm_path),
     'CMEPS/ufs/ccpp/data/MED_typedefs.F90',
     'CMEPS/ufs/ccpp/data/MED_data.F90'
     ]
@@ -58,13 +58,13 @@ TYPEDEFS_NEW_METADATA = {
 
 # Add all physics scheme files relative to basedir
 SCHEME_FILES = [
-    '{}/ccpp/physics/physics/SFC_Models/Ocean/UFS/sfc_ocean.F'.format(fv3_path),
-    '{}/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f'.format(fv3_path),
-    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part1.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part2.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.F90'.format(fv3_path),
-    '{}/ccpp/physics/physics/SFC_Layer/UFS/sfc_diag.f'.format(fv3_path)
+    '{}/ccpp/physics/physics/SFC_Models/Ocean/UFS/sfc_ocean.F'.format(ufsatm_path),
+    '{}/ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f'.format(ufsatm_path),
+    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part1.F90'.format(ufsatm_path),
+    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part2.F90'.format(_path),
+    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.F90'.format(ufsatm_path),
+    '{}/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.F90'.format(ufsatm_path),
+    '{}/ccpp/physics/physics/SFC_Layer/UFS/sfc_diag.f'.format(ufsatm_path)
     ]
 
 # Default build dir, relative to current working directory,

--- a/ufs/ccpp/data/MED_typedefs.meta
+++ b/ufs/ccpp/data/MED_typedefs.meta
@@ -1358,7 +1358,7 @@
 [ccpp-table-properties]
   name = MED_typedefs
   type = module
-  relative_path = ../../../../../FV3/ccpp/physics/physics/hooks
+  relative_path = ../../../../../UFSATM/ccpp/physics/physics/hooks
   dependencies = machine.F,physcons.F90
 
 [ccpp-arg-table]


### PR DESCRIPTION
### Description of changes
This PR updates the CMEPS submodule in the UFS to reflect a recent name change in the atmospheric component of the UFS, from FV3 -> UFSATM.

### Specific notes
N/A

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

