### PR TITLE
add CDEPS inline data for GFS_surface_composites_pre/post

### DIFF
--- a/ufs/ccpp/data/MED_typedefs.F90
+++ b/ufs/ccpp/data/MED_typedefs.F90
@@ -169,6 +169,7 @@ module MED_typedefs
   type MED_control_type
     logical                       :: lseaspray                 !< flag for sea spray parameterization
     logical                       :: use_med_flux              !< flag for using atmosphere-ocean fluxes form mediator
+    logical                       :: use_cdeps_inline          !< default no data from cdeps inline
     integer                       :: ivegsrc                   !< land use dataset choice 0 => USGS, 1 => IGBP, 2 => UMD
     integer                       :: lsm                       !< flag for land surface model
     integer                       :: lsm_noahmp                !< flag for NOAH MP land surface model
@@ -215,6 +216,12 @@ module MED_typedefs
   type MED_coupling_type
     real(kind=kind_phys), pointer :: dtsfcin_med(:) => null() !< sfc latent heat flux over ocean
     real(kind=kind_phys), pointer :: dqsfcin_med(:) => null() !< sfc sensible heat flux over ocean
+    !-- lake surface temperature from cdeps inline
+    real(kind=kind_phys), pointer :: mask_dat   (:) => null()   !< land-sea mask from cdeps inline  
+    real(kind=kind_phys), pointer :: tsfco_dat  (:) => null()   !< sfc temperature from cdeps inline
+    real(kind=kind_phys), pointer :: tice_dat   (:) => null()   !< sfc temperature over ice from cdeps inline
+    real(kind=kind_phys), pointer :: hice_dat   (:) => null()   !< sfc ice thickness from cdeps inline
+    real(kind=kind_phys), pointer :: fice_dat   (:) => null()   !< sfc ice fraction from cdeps inline
     contains
       procedure :: create  => coupling_create !< allocate array data
   end type MED_coupling_type
@@ -644,6 +651,7 @@ module MED_typedefs
 
     model%lseaspray = .false.
     model%use_med_flux = .false.
+    model%use_cdeps_inline = .false.
     model%ivegsrc = 2
     model%redrag = .false.
     model%sfc_z0_type = 0
@@ -680,15 +688,29 @@ module MED_typedefs
 
   end subroutine control_initialize
 
-  subroutine coupling_create(coupling, im)
+  subroutine coupling_create(coupling, im, model)
     implicit none
     class(MED_coupling_type) :: coupling
     integer, intent(in)      :: im
+    type(MED_control_type), intent(in) :: model
 
     allocate(coupling%dtsfcin_med(im))
     coupling%dtsfcin_med = clear_val
     allocate(coupling%dqsfcin_med(im))
     coupling%dqsfcin_med = clear_val
+    
+    if (model%use_cdeps_inline) then
+      allocate (coupling%tsfco_dat(im))
+      coupling%tsfco_dat = clear_val
+      allocate (coupling%mask_dat(im))
+      coupling%mask_dat = clear_val
+      allocate (coupling%tice_dat(im))
+      coupling%tice_dat = clear_val
+      allocate (coupling%hice_dat(im))
+      coupling%hice_dat = clear_val
+      allocate (coupling%fice_dat(im))
+      coupling%fice_dat = clear_val
+    endif
 
   end subroutine coupling_create
 

--- a/ufs/ccpp/data/MED_typedefs.meta
+++ b/ufs/ccpp/data/MED_typedefs.meta
@@ -803,6 +803,12 @@
   units = flag
   dimensions = ()
   type = logical
+[use_cdeps_inline]
+  standard_name = do_cdeps_inline
+  long_name = flag for using data provided by CDEPS inline (default false)
+  units = flag
+  dimensions = ()
+  type = logical
 [ivegsrc]
   standard_name = control_for_vegetation_dataset
   long_name = land use dataset choice
@@ -1030,6 +1036,46 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+[tsfco_dat]
+  standard_name = sea_surface_temperature_from_data
+  long_name = sfc temperature
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (do_cdeps_inline)
+[mask_dat]
+  standard_name = land_sea_mask_from_data 
+  long_name = landmask
+  units = flag
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (do_cdeps_inline)
+[tice_dat]
+  standard_name = surface_skin_temperature_over_ice_from_data
+  long_name = surface skin temperature over ice
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (do_cdeps_inline)
+[hice_dat]
+  standard_name = sea_ice_thickness_from_data
+  long_name = sea-ice thickness
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (do_cdeps_inline)
+[fice_dat]
+  standard_name = sea_ice_area_fraction_of_sea_area_fraction_from_data
+  long_name = sea-ice concentration [0,1]
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (do_cdeps_inline)
 
 ########################################################################
 [ccpp-table-properties]

--- a/ufs/flux_atmocn_ccpp_mod.F90
+++ b/ufs/flux_atmocn_ccpp_mod.F90
@@ -137,7 +137,7 @@ contains
        call physics%statein%create(nMax,physics%model)
        call physics%stateout%create(nMax)
        call physics%interstitial%create(nMax)
-       call physics%coupling%create(nMax)
+       call physics%coupling%create(nMax,physics%model)
        call physics%grid%create(nMax)
        call physics%sfcprop%create(nMax,physics%model)
        call physics%diag%create(nMax)


### PR DESCRIPTION
### Description of changes

This PR should have no actual effect on CMEPS. The CCPP suite that CMEPS is calling contains 2 schemes that have changed interfaces from https://github.com/ufs-community/ccpp-physics/pull/298. Specifically, more variables are required by GFS_surface_composites_pre/post. This PR simply adds these variables to the typedefs and metadata so that CMEPS can successfully compile and run with the ccpp-physics changes. The behavior of the 2 schemes with changed interfaces should not change as long as the preprocessor directive `CDEPS_INLINE` is not defined (by default) and the `USE_CDEPS_INLINE` environment variable is set to False (by default).

### Specific notes

Contributors other than yourself, if any:
@uturuncoglu 

CMEPS Issues Fixed (include github issue #):
None

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
Should be b4b

Any User Interface Changes (namelist or namelist defaults changes)?
No

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

UFS RTs on Ursa

