### PR TITLE
[production/GFS.v17] Add output_dir argument to log_restart_fh function

### DIFF
--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -493,7 +493,7 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 #ifndef CESMCOUPLED
        if (maintask) then
-         call log_restart_fh(nextTime, startTime, 'cmeps', rc=rc)
+         call log_restart_fh(nextTime, startTime, 'cmeps', output_dir=restart_dir, rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
        endif
 #endif


### PR DESCRIPTION
### Description of changes

NCO is requiring that subcomponent logs be written to the output or restart directories. This PR adds a new output_dir function to  the log_restart_fh call and sets it to the restart_dir. The CMEPS logs will now appear in ./CMEPS_RESTART/.

There will be a develop version of this feature with user accessibility from configuration options, but for production, this will be the default mode. 

### Specific notes

Contributors other than yourself, if any: None

CMEPS Issues Fixed (include github issue #): No issue for this production change

Are changes expected to change answers? No

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed
This was tested using the the UFSWM RT suite of tests on the production/GFSv17 branch

